### PR TITLE
Hacer que DAV cargue desde ComponentesDAV en vez de luigiIntegracionV1

### DIFF
--- a/ComponentesDAV/Dav/scr/gui/dav_commands.py
+++ b/ComponentesDAV/Dav/scr/gui/dav_commands.py
@@ -17,9 +17,13 @@ def _dav_repo_root() -> Path | None:
             return mod_path.parent
     try:
         here = Path(__file__).resolve()
+        # ComponentesDAV tiene prioridad: al subir ancestros aparece "Dav"
+        # antes que "ComponentesDAV", así que se busca primero el repo de
+        # componentes en toda la cadena y solo se cae a "DAV" si no aparece.
         for ancestor in here.parents:
             if ancestor.name.upper() == "COMPONENTESDAV":
                 return ancestor
+        for ancestor in here.parents:
             if ancestor.name.upper() == "DAV":
                 return ancestor
     except (IndexError, NameError):

--- a/ComponentesDAV/IntegracionGUI/GUIFreeCad/integration/browser_voice_adapter.py
+++ b/ComponentesDAV/IntegracionGUI/GUIFreeCad/integration/browser_voice_adapter.py
@@ -3,8 +3,22 @@ BrowserVoiceAdapter: connects Vosk spoken phrases to the new Browser navigation 
 """
 
 from __future__ import annotations
+
+import unicodedata
 from typing import Any
+
 from navigation.browser import Browser
+
+
+def _normalize(text: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", text)
+    stripped = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return " ".join(stripped.lower().split())
+
+
+_SEND_WORDS = {"enviar", "send"}
+_CANCEL_WORDS = {"cancelar", "cancel"}
+
 
 class BrowserVoiceAdapter:
     """Adapter to feed the raw phrase directly to the Browser's ProcessPhrase."""
@@ -21,13 +35,47 @@ class BrowserVoiceAdapter:
         self._stop_requested = True
 
     def procesar_frase_final(self, raw_phrase: str) -> None:
-        if self._stop_requested:
+        if self._stop_requested or not raw_phrase:
             return
 
+        normalized = _normalize(raw_phrase)
         print(f"[BrowserVoiceAdapter] Received phrase: '{raw_phrase}'")
-        result = self._browser.ProcessPhrase(raw_phrase)
 
-        if result.Success:
-            print(f"[DAV Browser] Success ({result.Action}): {result.Message}")
-        else:
-            print(f"[DAV Browser] Ignored: {result.Message}")
+        token = self._extract_token(normalized)
+        if token is None:
+            return
+        if token is False:
+            print("[DAV Browser] Cancelled.")
+            return
+
+        # Acciones que cambian de nivel: tras ellas mostramos el contexto.
+        _NAV_ACTIONS = {"descend", "back", "base_jump"}
+
+        def _run() -> None:
+            result = self._browser.ProcessPhrase(token)
+            if result.Success:
+                print(f"[DAV Browser] Success ({result.Action}): {result.Message}")
+                if result.Action in _NAV_ACTIONS:
+                    print(self._browser.DescribeContext())
+            else:
+                print(f"[DAV Browser] Ignored: {result.Message}")
+
+        try:
+            from integration.freecad_gui_bridge import run_on_main_thread
+            run_on_main_thread(_run)
+        except ImportError:
+            _run()
+
+    @staticmethod
+    def _extract_token(normalized: str):
+        """Return command token, False for cancel, None to ignore."""
+        for word in _CANCEL_WORDS:
+            if normalized == word or normalized.endswith(" " + word):
+                return False
+        for word in _SEND_WORDS:
+            if normalized.endswith(" " + word):
+                token = normalized[: -(len(word) + 1)].strip()
+                return token or None
+            if normalized == word:
+                return None
+        return normalized or None

--- a/ComponentesDAV/IntegracionGUI/GUIFreeCad/integration/voice_bootstrap.py
+++ b/ComponentesDAV/IntegracionGUI/GUIFreeCad/integration/voice_bootstrap.py
@@ -42,8 +42,12 @@ def start_voice_engine(*, debug: bool = False) -> bool:
 
         preferences.SetLanguage = LanguageCode.FromStorage(settings.language)
 
+        from pathlib import Path
+        # parents[0]=integration [1]=GUIFreeCad [2]=IntegracionGUI
+        # [3]=ComponentesDAV [4]=DAV (raíz del repo)
+        _dict_root = Path(__file__).resolve().parents[4] / "DiccionariosEnBruto"
         executor = PromptedCommandExecutor(Language=settings.language)
-        browser = Browser(prefs=preferences, on_execute=executor)
+        browser = Browser(dictionary_root=_dict_root, prefs=preferences, on_execute=executor)
         adapter = BrowserVoiceAdapter(browser)
         
         if not svc.start_cad(adapter):

--- a/ComponentesDAV/IntegracionGUI/GUIFreeCad/navigation/browser.py
+++ b/ComponentesDAV/IntegracionGUI/GUIFreeCad/navigation/browser.py
@@ -63,6 +63,10 @@ class Browser:
     real dictionary on disk (inject a mock DictionaryLoader).
     """
 
+    # Palabras que suben un nivel en la navegación (ya normalizadas: sin
+    # acentos ni mayúsculas, según DictionaryLoader.NormalizeSpoken).
+    _BACK_WORDS = frozenset({"volver", "atras", "salir", "subir", "regresar"})
+
     def __init__(
         self,
         dictionary_root: Path | str | None = None,
@@ -114,6 +118,50 @@ class Browser:
     def SetLanguage(self, value: LanguageCode) -> None:
         self._prefs.SetLanguage = value
 
+    @property
+    def CurrentContextName(self) -> str:
+        """Internal name of the context the user is currently in."""
+        return self._stack[-1].InternalName if self._stack else "Base"
+
+    @property
+    def ContextPath(self) -> str:
+        """Breadcrumb of the navigation stack, e.g. ``Base > explorer > file``."""
+        return " > ".join(frame.InternalName for frame in self._stack)
+
+    def DescribeContext(self) -> str:
+        """Human-readable summary of where you are and what you can say.
+
+        Lists the spoken words available in the current context, marking
+        sub-menus (descend) apart from directly executable commands. Used by
+        the voice adapter to print the context as the user moves around.
+        """
+        submenus: list[str] = []
+        commands: list[str] = []
+        seen_targets: list[Any] = []
+        for entry in self.Context:
+            # Un mismo destino suele tener varios alias (la palabra hablada
+            # "nuevo" y la clave interna "new"). _BuildContextForFrame agrega
+            # primero las habladas del TraduceTo, así que nos quedamos con la
+            # primera vista por destino (la español) y omitimos el resto.
+            if any(entry.Target is t for t in seen_targets):
+                continue
+            seen_targets.append(entry.Target)
+            if entry.IsSubContext():
+                submenus.append(entry.Spoken)
+            elif entry.IsCallable():
+                commands.append(entry.Spoken)
+
+        lines = [f"[DAV] Contexto: {self.ContextPath}"]
+        if submenus:
+            lines.append("  Submenús (entrar): " + ", ".join(sorted(submenus)))
+        if commands:
+            lines.append("  Comandos (ejecutar): " + ", ".join(sorted(commands)))
+        if self._IsDescended():
+            lines.append("  Decí «volver» para subir un nivel.")
+        if not submenus and not commands:
+            lines.append("  (sin comandos en este contexto)")
+        return "\n".join(lines)
+
     def ResetFromBase(self) -> None:
         """Reload BaseContext and Context from base.py (current language)."""
         self._language = self._prefs.SetLanguage
@@ -149,6 +197,30 @@ class Browser:
         if not normalized:
             return BrowserResult(False, "empty", "Empty phrase")
 
+        # Comando reservado "volver": sube un nivel (file → explorer → base).
+        # Funciona en cualquier contexto sin depender de los diccionarios.
+        if normalized in self._BACK_WORDS:
+            if self._IsDescended():
+                parent = self._AscendOneLevel()
+                return BrowserResult(True, "back", f"Context set to {parent}")
+            return BrowserResult(False, "back", "Already at root context")
+
+        # El contexto actual tiene prioridad sobre el salto base: si ya
+        # descendimos a un subcontexto, una palabra que también existe en el
+        # Base (p. ej. "archivo" sirve para entrar a explorer y, dentro de
+        # explorer, para bajar a "file") debe resolverse contra el nivel
+        # actual primero. Así "archivo → archivo → nuevo" baja por niveles en
+        # vez de quedar saltando siempre al mismo contexto base.
+        if self._IsDescended():
+            entry = FindBySpoken(self.Context, normalized)
+            if entry is not None:
+                if entry.IsSubContext():
+                    self._DescendToSubContext(entry)
+                    return BrowserResult(True, "descend", f"Context set to {entry.InternalKey}")
+                if entry.IsCallable():
+                    self._ExecuteEntry(entry)
+                    return BrowserResult(True, "execute", f"Executed {entry.InternalKey}")
+
         # Requirement 2 (Developer 2): direct jump for BaseContext commands
         base_hit = self._ResolveBaseJump(normalized)
         if base_hit is not None:
@@ -169,6 +241,22 @@ class Browser:
                 return BrowserResult(True, "execute", f"Executed {entry.InternalKey}")
 
         return self._SearchUpwardAndExecute(normalized)
+
+    def _IsDescended(self) -> bool:
+        """True si estamos dentro de un subcontexto (no en el nivel base)."""
+        return len(self._stack) > 1
+
+    def _AscendOneLevel(self) -> str:
+        """Sube un nivel: descarta el frame actual y reconstruye el padre.
+
+        Returns:
+            El nombre interno del contexto al que se volvió.
+        """
+        self._stack.pop()
+        parent = self._stack[-1]
+        self.Context = self._BuildContextForFrame(parent)
+        self.OriginalContext = None
+        return parent.InternalName
 
     # ------------------------------------------------------------------
     # Internal helpers (Developer 2)

--- a/ComponentesDAV/IntegracionGUI/GUIFreeCad/navigation/dictionary_loader.py
+++ b/ComponentesDAV/IntegracionGUI/GUIFreeCad/navigation/dictionary_loader.py
@@ -15,22 +15,11 @@ from typing import Any
 
 from core.language_code import LanguageCode
 
-def _find_keychain_root() -> Path:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "Keychain").is_dir():
-            return parent
-    return here.parents[4]
-
-_KEYCHAIN_ROOT = _find_keychain_root()
+_KEYCHAIN_ROOT = Path(__file__).resolve().parents[3] / "ComponentesDAV"
 if str(_KEYCHAIN_ROOT) not in sys.path:
     sys.path.insert(0, str(_KEYCHAIN_ROOT))
 
-_gui_parent = str(Path(__file__).resolve().parents[2])
-if _gui_parent not in sys.path:
-    sys.path.insert(0, _gui_parent)
-
-from ComponentesDAV.Keychain.Keychain import Keychain  # noqa: E402
+from Keychain.Keychain import Keychain  # noqa: E402
 
 
 class DictionaryLoader:
@@ -59,7 +48,15 @@ class DictionaryLoader:
     def LoadBaseModuleDict(self) -> dict[str, Any]:
         if not self.IsReady:
             return {}
-        module = importlib.import_module("base")
+        try:
+            module = importlib.import_module("base")
+        except Exception as error:  # noqa: BLE001 - aislar base.py roto
+            print(
+                f"[DAV-Browser] No se pudo cargar 'base.py' en {self.DictionaryRoot}: "
+                f"{error.__class__.__name__}: {error}. El motor arranca con "
+                "BaseContext vacío."
+            )
+            return {}
         base = getattr(module, "Base", None)
         if not isinstance(base, dict):
             raise ValueError("base.py must define dict Base = {...}")
@@ -72,7 +69,18 @@ class DictionaryLoader:
             path = folder / f"{stem}.py"
             if not path.is_file():
                 continue
-            module = self._ImportTranslateModule(path, stem)
+            # Si un diccionario está roto (import relativo inválido, sintaxis,
+            # etc.) no se debe tumbar todo el motor: se omite y se sigue con
+            # el resto. Browser tolera un mapa vacío sin fallar.
+            try:
+                module = self._ImportTranslateModule(path, stem)
+            except Exception as error:  # noqa: BLE001 - aislar diccionario roto
+                print(
+                    f"[DAV-Browser] No se pudo cargar el diccionario '{path}': "
+                    f"{error.__class__.__name__}: {error}. Se omite y se "
+                    "continúa con los diccionarios disponibles."
+                )
+                continue
             table = getattr(module, stem, None)
             if isinstance(table, dict):
                 return dict(table)
@@ -142,6 +150,10 @@ class DictionaryLoader:
         return " ".join(stripped.lower().split())
 
     def _ImportTranslateModule(self, path: Path, stem: str) -> ModuleType:
-        rel = path.relative_to(self.DictionaryRoot).with_suffix("")
+        # resolve() returns the actual filesystem casing on Windows, so the
+        # computed module name matches what is already cached in sys.modules.
+        resolved_path = path.resolve()
+        resolved_root = self.DictionaryRoot.resolve()
+        rel = resolved_path.relative_to(resolved_root).with_suffix("")
         module_name = ".".join(rel.parts)
         return importlib.import_module(module_name)

--- a/iniciar_dav.ps1
+++ b/iniciar_dav.ps1
@@ -1,3 +1,3 @@
-# Wrapper: delega en luigiIntegracionV1/iniciar_dav.ps1
-& "$PSScriptRoot\luigiIntegracionV1\iniciar_dav.ps1" @args
+# Wrapper: delega en ComponentesDAV/IntegracionGUI/iniciar_dav.ps1
+& "$PSScriptRoot\ComponentesDAV\IntegracionGUI\iniciar_dav.ps1" @args
 exit $LASTEXITCODE


### PR DESCRIPTION
## Resumen

DAV cargaba el motor de voz desde `luigiIntegracionV1/GUIFreeCad` en vez del componente oficial en `ComponentesDAV`. Este PR corrige la resolución de rutas, sincroniza los arreglos de navegación al componente oficial y redirige el launcher.

## Cambios

1. **Priorizar ComponentesDAV sobre Dav** — `_dav_repo_root()` en `dav_commands.py` encontraba la carpeta `Dav` antes que `ComponentesDAV` al subir ancestros y devolvía la raíz equivocada, rompiendo la resolución y cargando luigi. Ahora busca primero `ComponentesDAV` en toda la cadena.
2. **Sincronizar arreglos de navegación** — se copiaron a `ComponentesDAV/IntegracionGUI/GUIFreeCad` los arreglos de `browser.py`, `dictionary_loader.py` y `browser_voice_adapter.py` (tolerancia a diccionarios rotos, prioridad de contexto, comando «volver», mostrar contexto), preservando el `_DefaultDictionaryRoot` propio de ComponentesDAV. El bootstrap ahora apunta a `DiccionariosEnBruto`.
3. **Launcher raíz** — `iniciar_dav.ps1` delegaba en `luigiIntegracionV1`; ahora delega en `ComponentesDAV/IntegracionGUI/iniciar_dav.ps1` (que usa el `.venv` de ComponentesDAV).

## Cómo probar

Ejecutar `iniciar_dav.bat` de la raíz: debe abrir FreeCAD usando ComponentesDAV. Iniciar voz DAV y navegar (`archivo` → `archivo` → `abrir`, `volver`, etc.).