### PR TITLE
Actualizar AVANCES de diccionarios tras contraste con codigo real

### DIFF
--- a/Dav/dic/AVANCES_EXPLORER.md
+++ b/Dav/dic/AVANCES_EXPLORER.md
@@ -1,6 +1,34 @@
 # Avances — Módulo Explorer
 
-> Revisado: 2026-06-03 — Bugs #1–#8 corregidos
+> Revisado: 2026-06-25 (contraste código vs. avances)
+> Revisión previa: 2026-06-03 — Bugs #1–#8 corregidos
+
+---
+
+## ⚠️ Cambio de arquitectura (2026-06-25): Explorer dejó de ser plano
+
+La revisión 2026-06-03 describía `Explorer.py` con `.update()` aplanando todos los
+submódulos en un único nivel. **El código real ya no funciona así.** `Explorer.py`
+ahora arma **subcontextos anidados** porque el Browser navega por niveles y
+`Explorer/TraduceTo*.py` espera `explorer['file']`, `explorer['edit']`, etc. como submenús:
+
+```python
+explorer = {}
+explorer.update({'file': file})
+explorer.update({'edit': edit})
+explorer.update({'print': print_cmds})
+explorer.update({'windows': windows})
+explorer.update({'expressions': expressions})
+explorer.update({'tools': tools})
+explorer.update({'structure': structure})
+# callables sueltos al ras + 'help': ayuda
+```
+
+**Consecuencia:** los "bugs de colisión por aplanamiento" del 2026-06-03 (`'paste'` vs
+`edit['paste']`, `'screenshot'` duplicado, etc.) **ya no aplican** — al estar anidados,
+las mismas claves en submódulos distintos no colisionan. La tabla de cobertura de
+abajo sigue siendo válida en cuanto a qué ticket vive en qué archivo, pero la ruta de
+invocación por voz ahora pasa por el nombre del subcontexto (`file`, `edit`, …).
 
 ---
 
@@ -8,18 +36,22 @@
 
 ```
 Explorer/
-├── Explorer.py                  ← raíz, usa .update()
+├── Explorer.py                  ← raíz, subcontextos ANIDADOS (no aplanado)
 ├── AdditionalTools/Additional.py
 ├── Edit/Edit.py
 ├── Expressions/Expressions.py
 ├── File/File.py
 ├── Print/Print.py
 ├── StructureToolbar/
-│   ├── structure.py
-│   └── linkActions/link.py
+│   ├── StructureToolbar.py      ← (la doc previa lo llamaba structure.py)
+│   └── linkActions/linkActions.py  ← (la doc previa lo llamaba link.py)
 ├── Tools/Tools.py
 └── Windows/Windows.py
 ```
+
+> Nota: `print_cmds` es el dict de `Print/Print.py` (renombrado para no pisar el
+> builtin `print`). `AdditionalTools/Additional.py` no aparece importado en el
+> `Explorer.py` actual — su contenido (`linkgroups`) requiere reverificación.
 
 ---
 
@@ -77,14 +109,14 @@ Explorer/
 | `Std_CloseActiveWindow` | `Gui.runCommand('Std_CloseActiveWindow', 0)` | `Windows.py` | `'close'` |
 | `Std_CloseAllWindows` | `Gui.runCommand('Std_CloseAllWindows', 0)` | `Windows.py` | `'closeall'` |
 | `Std_Quit` | `Gui.getMainWindow().close()` | `Windows.py` | `'quit'` |
-| `Std_Group` | `Gui.runCommand('Std_Group', 0)` | `structure.py` | `'newgroup'` |
-| `Std_Part` | `Gui.runCommand('Std_Part', 0)` | `structure.py` | `'part'` |
-| `Std_LinkMake` | `Gui.runCommand('Std_LinkMake', 0)` | `link.py` | `'makelink'` |
-| `Std_LinkMakeRelative` | `Gui.runCommand('Std_LinkMakeRelative', 0)` | `link.py` | `'relativelink'` |
-| `Std_LinkImport` | `Gui.runCommand('Std_LinkImport', 0)` | `link.py` | `'importlink'` |
-| `Std_LinkImportAll` | `Gui.runCommand('Std_LinkImportAll', 0)` | `link.py` | `'importalllinks'` |
-| `Std_LinkReplace` | `Gui.runCommand('Std_LinkReplace', 0)` | `link.py` | `'replacelink'` |
-| `Std_LinkMakeGroup` | `Gui.runCommand('Std_LinkMakeGroup', 0)` | `Additional.py` | `'linkgroups'` |
+| `Std_Group` | `Gui.runCommand('Std_Group', 0)` | `StructureToolbar.py` | `'newgroup'` |
+| `Std_Part` | `Gui.runCommand('Std_Part', 0)` | `StructureToolbar.py` | `'part'` |
+| `Std_LinkMake` | `Gui.runCommand('Std_LinkMake', 0)` | `linkActions.py` | `'makelink'` |
+| `Std_LinkMakeRelative` | `Gui.runCommand('Std_LinkMakeRelative', 0)` | `linkActions.py` | `'relativelink'` |
+| `Std_LinkImport` | `Gui.runCommand('Std_LinkImport', 0)` | `linkActions.py` | `'importlink'` |
+| `Std_LinkImportAll` | `Gui.runCommand('Std_LinkImportAll', 0)` | `linkActions.py` | `'importalllinks'` |
+| `Std_LinkReplace` | `Gui.runCommand('Std_LinkReplace', 0)` | `linkActions.py` | `'replacelink'` |
+| `Std_LinkMakeGroup` ⚠️ | `Gui.runCommand('Std_LinkMakeGroup', 0)` | `AdditionalTools/Additional.py` | `'linkgroups'` — **archivo NO importado en Explorer.py (huérfano, 2026-06-25)** |
 
 ### ⚠️ Cubiertos con API alternativa (aceptable)
 
@@ -104,10 +136,10 @@ Explorer/
 | 2 | `Tools/Tools.py` | `'proyectutil'` — typo, falta la "j" | → `'projectutil'` |
 | 3 | `StructureToolbar/structure.py` | `'new Group'` y `'link actions'` tienen espacios en las claves | → `'newgroup'`, `'linkactions'` |
 | 4 | `StructureToolbar/linkActions/link.py` | `'make link'`, `'relative link'`, `'import link'`, `'import all links'`, `'replace link'` — todas con espacios | → `'makelink'`, `'relativelink'`, `'importlink'`, `'importalllinks'`, `'replacelink'` |
-| 5 | `Explorer.py` | `StructureToolbar/structure` y `AdditionalTools/Additional` no estaban importados — módulos huérfanos | Importados y agregados al `.update()` |
+| 5 | `Explorer.py` | `StructureToolbar` no estaba importado | ✅ Importado como subcontexto `explorer['structure']`. ⚠️ `AdditionalTools/Additional` **sigue sin importarse** (huérfano — ver nota) |
 | 6 | `Edit.py` | `'screenshot'` y `'note'` duplicados respecto a `Explorer.py` | Eliminados de `Edit.py` |
 | 7 | `Edit.py`, `Tools.py`, `Expressions.py` | Cabezal duplicado (dos líneas `Copyright`) | Unificado a un solo bloque GPL-3.0 |
-| 8 | `Expressions.py` | `'paste'` colisionaba con `edit['paste']` al aplanar con `.update()` | → `'pasteexpr'` |
+| 8 | `Expressions.py` | `'paste'` colisionaba con `edit['paste']` al aplanar con `.update()` | ➖ Ya no aplica — Explorer pasó a subcontextos anidados; `expressions` es su propio nivel (`explorer['expressions']`) y no colisiona |
 
 ---
 
@@ -115,4 +147,10 @@ Explorer/
 
 Ninguno. Todos los 59 tickets de Explorer tienen cobertura en algún archivo del módulo.
 
-> **Nota:** `Std_Group`, `Std_Part` y los `Std_Link*` están en `StructureToolbar/` — bug #5 corregido, ya están importados y activos en `Explorer.py`.
+> **Nota (2026-06-25):** `Std_Group`, `Std_Part` y los `Std_Link*` están en
+> `StructureToolbar/` y se navegan vía `explorer['structure']` (y dentro,
+> `structure['linkactions']`, que también es un subcontexto anidado, no aplanado).
+> **Pendiente:** `AdditionalTools/Additional.py` (clave `'linkgroups'` →
+> `Std_LinkMakeGroup`) no está importado en el `Explorer.py` actual. Hay que
+> decidir si se agrega como subcontexto o se descarta — `Std_LinkMakeGroup` no
+> está cubierto en ningún otro archivo activo.

--- a/Dav/dic/AVANCES_GENERAL.md
+++ b/Dav/dic/AVANCES_GENERAL.md
@@ -1,6 +1,7 @@
 # Avances Generales — Diccionarios DAV
 
-> Actualizado: 2026-06-03
+> Actualizado: 2026-06-25 (contraste código vs. avances — sesión de reconciliación)
+> Revisión previa: 2026-06-03
 
 ---
 
@@ -8,15 +9,60 @@
 
 | Módulo | Tickets | Cobertura | Bugs pendientes | Estado |
 | ------ | ------- | --------- | --------------- | ------ |
-| **Explorer** | 59 | 59/59 ✅ | 0 | ✅ Listo |
+| **Explorer** | 59 | 59/59 ✅ | 0 — reestructurado a subcontextos anidados | ✅ Listo |
 | **LineAttributes** | 2 | 2/2 ✅ | 0 | ✅ Listo |
 | **StdView** | 99 | 99/99 ✅ | 0 | ✅ Listo |
 | **Workbench/Assembly** | 22 | 22/22 ✅ | 0 | ✅ Listo |
-| **Workbench/PartDesign** | 36 | 36/36 ✅ | 0 — corregido 2026-06-03 | ✅ Listo |
-| **Workbench/Sketcher** | 97 | 94/97 ✅ | 1 (`refraction`) + `intersection` por verificar versión | ⚠️ Casi completo |
-| **Workbench/DraftWork** | 59 | 59/59 ✅ | 0 — corregido 2026-06-03 | ✅ Listo |
-| **Workbench/TechDraw** | 44/44 ✅ | 44/44 ✅ | 0 — corregido 2026-06-03 | ✅ Listo |
-| **Workbench/Part** | 24 | 24/24 ✅ | 0 — operaciones migradas a Opción B (API directa) 2026-06-03 | ✅ Listo |
+| **Workbench/PartDesign** | 36 | 36/36 ✅ | 0 | ✅ Listo |
+| **Workbench/Sketcher** | 97 | 94/97 ✅ | 1 (`refraction` — sigue faltando) + `intersection` por verificar versión | ⚠️ Casi completo |
+| **Workbench/DraftWork** | 59 | 59/59 ✅ | 1 menor (`modification.py`: claves con guión bajo + falta cabezal GPL) | ⚠️ Funcional, falta nomenclatura |
+| **Workbench/TechDraw** | 44/44 ✅ | 44/44 ✅ | 3 menores (claves camelCase; root usa `'ayuda'` en vez de `'help'`; `dimensions['angle']=angle` en vez de `.update`); leftovers `help.py` | ⚠️ Funcional, falta limpieza |
+| **Workbench/Part** | 24 | 24/24 ✅ | 3 menores (`cube` duplicado; claves con espacios; `new_sketch` debería ir a Sketcher); root usa `'ayuda'` | ⚠️ Funcional, falta limpieza |
+
+---
+
+## ⚠️ Reconciliación 2026-06-25 — la documentación previa estaba desactualizada
+
+El código de los diccionarios fue modificado después del 2026-06-03 y los `AVANCES_*.md`
+no reflejaban el estado real. Diferencias detectadas al contrastar código vs. avances:
+
+### Cambios de arquitectura no documentados
+
+1. **`_lenient.LenientDict`** — nuevo wrapper aplicado en `DraftWork.py` y
+   `Dimensions/dimensions.py`. Hace que el dict tolere claves aún no implementadas
+   sin romper el contexto. No figura en ninguna versión previa de los avances.
+2. **Explorer dejó de ser plano.** La doc previa describía `Explorer.py` con `.update()`
+   y claves aplanadas. El código real usa **subcontextos anidados**
+   (`explorer['file']`, `explorer['edit']`, `explorer['tools']`, …) porque el Browser
+   navega por niveles. Esto invalida la premisa de varios "bugs de colisión por
+   aplanamiento" listados en 2026-06-03 (ya no aplican).
+3. **Nombres de archivo raíz** difieren de la doc previa:
+   `DraftWork.py` (no `workbench.py`), `Part.py` (no `PartWorkbench.py`),
+   `TechDraw.py` (no `TechDrawWorkbench.py`), `StructureToolbar.py` (no `structure.py`),
+   `circular_array/circular_array.py` (no `array.py`),
+   `annotation_style_editor/annotation_style_editor.py` (no `annotation.py`).
+
+### Bugs que la doc previa daba como PENDIENTES y ya están corregidos en código
+
+- **DraftWork**: `DraftWork.py` ya importa `Drafting`, `creation`, `modification`
+  (bug #1 resuelto); `creation.py` usa `import FreeCADGui as Gui` correctamente
+  (bug #2 resuelto); carpetas `snap/` y `modification/array/` eliminadas (bugs #6, #7);
+  `annotation.py` usa `'shapestring'` (bug #8); `circular_array.py` usa
+  `'pathlink'`/`'pointlink'` (bug #9).
+- **TechDraw**: `TechDraw.py` ya importa los 12 submódulos, incluidos `Page`,
+  `Annotations`, `Hatching`, `AddVertices`, `OtherViews`, `Features` (bug #1 resuelto).
+
+### Bugs que siguen presentes (verificados en código 2026-06-25)
+
+- **Sketcher** `geometric/geometric.py`: falta `'refraction'` → `Sketcher_ConstrainSnellsLaw`.
+- **DraftWork** `modification/modification.py`: claves con guión bajo
+  (`shape_2d_view`, `subelement_highlight`, `wire_to_bspline`) y sin cabezal GPL.
+- **TechDraw** `dimensions.py`: usa `dimensions['angle'] = angle` en vez de `.update(angle)`.
+- **TechDraw** `TechDraw.py` y **Part** `Part.py`: la clave de ayuda raíz es `'ayuda'`,
+  inconsistente con `'help'` que usa el resto del proyecto y CONTEXT.md.
+- **TechDraw**: subcarpetas `Annotations/`, `Hatching/`, `AddVertices/`, `OtherViews/`
+  conservan archivos `help.py` además de `ayuda.py` (leftovers a eliminar).
+- **Part**: `cube` duplicado semántico de `box`; claves con espacios pendientes; `new_sketch`.
 
 ---
 

--- a/Dav/dic/AVANCES_LINEATTRIBUTES.md
+++ b/Dav/dic/AVANCES_LINEATTRIBUTES.md
@@ -1,6 +1,9 @@
 # Avances — Módulo LineAttributes
 
-> Revisado: 2026-06-03
+> Revisado: 2026-06-03 · Reconfirmado contra código 2026-06-25
+>
+> Verificado 2026-06-25: `LineAttributes.py` usa `.update(attributes)` + `'help': ayuda`.
+> La doc coincide con el código; sin cambios.
 
 ---
 

--- a/Dav/dic/AVANCES_STDVIEW.md
+++ b/Dav/dic/AVANCES_STDVIEW.md
@@ -1,6 +1,9 @@
 # Avances — Módulo StdView
 
-> Revisado: 2026-06-03 · Estado: ✅ Diccionarios listos
+> Revisado: 2026-06-03 · Reconfirmado contra código 2026-06-25 · Estado: ✅ Diccionarios listos
+>
+> Verificado 2026-06-25: `StdView.py` sigue plano con `.update()`, exporta `Panels`
+> (mayúscula) y `StandardViews`, y usa `'help': ayuda`. La doc coincide con el código.
 
 ---
 

--- a/Dav/dic/AVANCES_WORKBENCH.md
+++ b/Dav/dic/AVANCES_WORKBENCH.md
@@ -1,8 +1,14 @@
 # Avances — Módulo Workbench
 
-> Revisado: 2026-06-03
+> Revisado: 2026-06-25 (contraste código vs. avances)
+> Revisión previa: 2026-06-03
 
 Cubre: Assembly, DraftWork, Part, PartDesign, Sketcher, TechDraw (auditado íntegramente)
+
+> **Nota 2026-06-25:** el código se modificó después del 2026-06-03 (se agregó
+> `_lenient.LenientDict`, se importaron submódulos antes huérfanos y se renombraron
+> archivos raíz). Las secciones de DraftWork y TechDraw fueron actualizadas para
+> reflejar el estado real. Ver `AVANCES_GENERAL.md` → "Reconciliación 2026-06-25".
 
 ---
 
@@ -56,24 +62,26 @@ Workbench/Assembly/
 
 ```
 Workbench/DraftWork/
-├── workbench.py             ← raíz, usa .update() — IMPORTA SOLO 9 de 12 subcarpetas
+├── DraftWork.py             ← raíz, usa .update() + LenientDict — importa TODAS las subcarpetas ✅
 ├── annotation/annotation.py
-├── annotation_style_editor/annotation.py
+├── annotation_style_editor/annotation_style_editor.py
 ├── arc/arc.py
 ├── circle/circle.py
-├── circular_array/array.py  ← importado como 'array' en workbench.py
-├── creation/creation.py     ← ❌ NO importado en workbench.py
+├── circular_array/circular_array.py  ← importado como 'array' en DraftWork.py
+├── creation/creation.py     ← ✅ importado (corregido)
 ├── curve/curve.py
 ├── dimension/dimension.py
-├── Drafting/drafting.py     ← ❌ NO importado en workbench.py
+├── Drafting/drafting.py     ← ✅ importado (corregido)
 ├── ellipse/ellipse.py
 ├── facebinder/facebinder.py
-├── modification/            ← ❌ NO importado en workbench.py
-│   ├── modification.py
-│   └── array/array.py
-├── modify/modify.py
-└── snap/snap.py             ← ❌ NO importado en workbench.py
+├── modification/modification.py  ← ✅ importado (corregido); subcarpeta array/ eliminada
+└── modify/modify.py
 ```
+
+> **Estado real 2026-06-25:** `DraftWork.py` (no `workbench.py`) importa los 12 submódulos
+> con `.update()` y envuelve el resultado en `LenientDict`. Las carpetas `snap/` y
+> `modification/array/` fueron **eliminadas**. Los archivos raíz y de subcarpeta fueron
+> renombrados (`DraftWork.py`, `circular_array.py`, `annotation_style_editor.py`).
 
 ### Cobertura (59 tickets Draft)
 
@@ -112,37 +120,39 @@ Workbench/DraftWork/
 | `Draft_Ellipse` | `Gui.runCommand('Draft_Ellipse', 0)` | `ellipse/ellipse.py` | `'center'` |
 | `Draft_Facebinder` | `Gui.runCommand('Draft_Facebinder', 0)` | `facebinder/facebinder.py` | `'create'` |
 
-**⚠️ Archivos con tickets cubiertos pero NO importados en workbench.py**
+**✅ Módulos antes huérfanos, ahora importados en `DraftWork.py` (corregido)**
 
-Estos módulos existen y tienen comandos correctos, pero `workbench.py` no los importa — los tickets que cubren están técnicamente inactivos:
+Estos módulos ya están activos en la raíz (antes la doc los daba como no importados):
 
 | Módulo | Tickets cubiertos | Estado |
 |--------|-----------------|--------|
-| `Drafting/drafting.py` | `Draft_Wire` | ❌ no importado |
-| `creation/creation.py` | `Draft_Hatch`, `Draft_Point`, `Draft_Polygon`, `Draft_Rectangle` | ❌ no importado |
-| `modification/modification.py` | `Draft_Scale`, `Draft_Shape2DView`, `Draft_Slope`, `Draft_Split`, `Draft_Stretch`, `Draft_SubelementHighlight`, `Draft_Trimex`, `Draft_Upgrade`, `Draft_WireToBSpline` | ❌ no importado |
-| `modification/array/array.py` | duplica arrays — ver bugs | ❌ no importado (y tiene bugs propios) |
-| `snap/snap.py` | `Draft_Mirror` | ❌ no importado |
+| `Drafting/drafting.py` | `Draft_Wire` | ✅ importado |
+| `creation/creation.py` | `Draft_Hatch`, `Draft_Point`, `Draft_Polygon`, `Draft_Rectangle` | ✅ importado |
+| `modification/modification.py` | `Draft_Scale`, `Draft_Shape2DView`, `Draft_Slope`, `Draft_Split`, `Draft_Stretch`, `Draft_SubelementHighlight`, `Draft_Trimex`, `Draft_Upgrade`, `Draft_WireToBSpline` | ✅ importado |
 
 **❌ Tickets sin ninguna cobertura**
 
 | Ticket | Comando | Nota |
 |--------|---------|------|
-| `Draft_Line` | `Draft.make_line(p1, p2)` | API Nivel 2 — no existe en ningún dict; `Draft_Wire` es el equivalente GUI pero semánticamente distinto |
+| `Draft_Line` | `Draft.make_line(p1, p2)` | API Nivel 2 — no existe en ningún dict; `Draft_Wire` (en `Drafting/`) es el equivalente GUI pero semánticamente distinto |
 
 ### Bugs DraftWork
 
-| # | Archivo | Problema | Corrección |
-|---|---------|----------|------------|
-| 1 | `workbench.py` | No importa `Drafting`, `creation`, `modification`, `snap` — 14 comandos inactivos | Agregar los 4 imports y sus `.update()` correspondientes |
-| 2 | `creation/creation.py` | `import FreeCad as Gui` — **typo grave**, crashea al importar | Cambiar a `import FreeCADGui as Gui` |
-| 3 | `modification/array/array.py` | `import FreeCad as Gui` — mismo typo grave | Cambiar a `import FreeCADGui as Gui` |
-| 4 | `modification/array/array.py` | Usa `Gui.runCommand('Draft_ArrayTools', N)` — comando inexistente; los arrays tienen comandos individuales | Reemplazar por los comandos correctos (ya cubiertos en `circular_array/array.py`) |
-| 5 | `snap/snap.py` | `import FreeCad as Gui` — typo grave | Cambiar a `import FreeCADGui as Gui` |
-| 6 | `snap/snap.py` | Carpeta `snap/` no tiene nada que ver con snap — contiene `Draft_Mirror`; nombre de carpeta engañoso | Mover `mirror` a `modify/modify.py` y eliminar `snap/` |
-| 7 | `modification/array/array.py` | Es un duplicado de `circular_array/array.py` con errores encima | Eliminar `modification/array/` completo; ya está cubierto |
-| 8 | `annotation/annotation.py` | `'shape_string'` tiene guión bajo — viola convención (sin separadores) | Renombrar a `'shapestring'` |
-| 9 | `circular_array/array.py` | `'path_link'` y `'point_link'` tienen guión bajo | Renombrar a `'pathlink'`, `'pointlink'` |
+> Bugs #1–#9 originales: la mayoría se corrigieron en código después del 2026-06-03.
+> Estado verificado el 2026-06-25.
+
+| # | Archivo | Problema | Estado |
+|---|---------|----------|--------|
+| 1 | `DraftWork.py` | No importaba `Drafting`, `creation`, `modification`, `snap` | ✅ Corregido — los 12 submódulos importados |
+| 2 | `creation/creation.py` | `import FreeCad as Gui` — typo grave | ✅ Corregido — usa `import FreeCADGui as Gui` |
+| 3 | `modification/array/array.py` | `import FreeCad as Gui` | ✅ Resuelto — carpeta eliminada |
+| 4 | `modification/array/array.py` | `Gui.runCommand('Draft_ArrayTools', N)` inexistente | ✅ Resuelto — carpeta eliminada (arrays cubiertos en `circular_array/`) |
+| 5 | `snap/snap.py` | `import FreeCad as Gui` | ✅ Resuelto — carpeta eliminada |
+| 6 | `snap/snap.py` | Nombre de carpeta engañoso (contenía `Draft_Mirror`) | ✅ Resuelto — carpeta eliminada |
+| 7 | `modification/array/array.py` | Duplicado de `circular_array/` | ✅ Resuelto — carpeta eliminada |
+| 8 | `annotation/annotation.py` | `'shape_string'` con guión bajo | ✅ Corregido — usa `'shapestring'` |
+| 9 | `circular_array/circular_array.py` | `'path_link'`/`'point_link'` con guión bajo | ✅ Corregido — usa `'pathlink'`/`'pointlink'` |
+| 10 | `modification/modification.py` | Claves con guión bajo: `'shape_2d_view'`, `'subelement_highlight'`, `'wire_to_bspline'` — violan convención (sin separadores); además falta el cabezal GPL | ⚠️ **Pendiente** — renombrar a `'shape2dview'`, `'subelementhighlight'`, `'wiretobspline'` y agregar cabezal |
 
 ---
 
@@ -459,37 +469,43 @@ La alternativa (Opción A) sería usar `Gui.runCommand('TechDraw_RadiusDimension
 | `TechDraw_Quadrants` | `Gui.runCommand('TechDraw_Quadrants', 0)` | `Snaps/Snaps.py` | `'quadrants'` |
 | `TechDraw_ShowAll` | `Gui.runCommand('TechDraw_ShowAll', 0)` | `Topology/Topology.py` | `'showAll'` |
 
-#### Archivos con tickets cubiertos pero NO importados en TechDrawWorkbench.py
+#### ✅ Módulos antes huérfanos, ahora importados en `TechDraw.py` (corregido)
+
+Verificado 2026-06-25: `TechDraw.py` (no `TechDrawWorkbench.py`) importa los 12 submódulos.
 
 | Módulo | Tickets cubiertos | Estado |
 | ------ | ---------------- | ------ |
-| `Page/Page.py` | `TechDraw_PageDefault`, `TechDraw_PageTemplate`, `TechDraw_RedrawPage`, `TechDraw_PrintAll`, `TechDraw_ExportPageDXF`, `TechDraw_ExportPageSVG` | ❌ no importado |
-| `Annotations/annotations.py` | `TechDraw_Annotation`, `TechDraw_AxoLengthDimension`, `TechDraw_Balloon` | ❌ no importado |
-| `Hatching/hatching.py` | `TechDraw_GeometricHatch` | ❌ no importado |
-| `AddVertices/addVertices.py` | `TechDraw_CosmeticVertex` | ❌ no importado |
-| `OtherViews/otherViews.py` | `TechDraw_ActiveView` | ❌ no importado |
-| `Features/Features.py` | `TechDraw_FillTemplateFields`, `TechDraw_Image`, `TechDraw_Symbol` | ❌ no importado |
-| `Symbols/weld.py` | `TechDraw_WeldSymbol` (duplicado de `Symbols.py`) | ❌ no importado y redundante |
+| `Page/Page.py` | `TechDraw_PageDefault`, `TechDraw_PageTemplate`, `TechDraw_RedrawPage`, `TechDraw_PrintAll`, `TechDraw_ExportPageDXF`, `TechDraw_ExportPageSVG` | ✅ importado |
+| `Annotations/annotations.py` | `TechDraw_Annotation`, `TechDraw_AxoLengthDimension`, `TechDraw_Balloon` | ✅ importado |
+| `Hatching/hatching.py` | `TechDraw_GeometricHatch` | ✅ importado |
+| `AddVertices/addVertices.py` | `TechDraw_CosmeticVertex` | ✅ importado |
+| `OtherViews/otherViews.py` | `TechDraw_ActiveView` | ✅ importado |
+| `Features/Features.py` | `TechDraw_FillTemplateFields`, `TechDraw_Image`, `TechDraw_Symbol` | ✅ importado |
+| `Symbols/weld.py` | `TechDraw_WeldSymbol` (duplicado) | ✅ eliminado — cubierto por `Symbols.py` |
 
 ### Bugs TechDraw
 
-| # | Archivo | Problema | Corrección |
-|---|---------|----------|------------|
-| 1 | `TechDrawWorkbench.py` | No importa `Page`, `Annotations`, `Hatching`, `AddVertices`, `OtherViews`, `Features` — 15 comandos inactivos | Agregar los 6 imports y sus `.update()` correspondientes |
-| 2 | `Views/view.py` | Archivo huérfano — versión antigua con 1 solo comando (`'view'`) sin cabezal GPL, nunca importado | Eliminar; `Views.py` ya lo reemplaza correctamente |
-| 3 | `Symbols/weld.py` | Duplica `TechDraw_WeldSymbol` con clave `'weld_symbol'` (guión bajo) — ya está en `Symbols.py` como `'weldSymbol'` | Eliminar `weld.py`; la cobertura ya existe |
-| 4 | `Annotations/annotations.py` | Usa `from .help import help` — nombre en inglés, inconsistente con el resto del proyecto (`ayuda`) | Renombrar archivo a `ayuda.py` y función a `ayuda` |
-| 5 | `Hatching/hatching.py` | Mismo problema: `from .help import help` | Ídem Bug 4 |
-| 6 | `AddVertices/addVertices.py` | Mismo problema: `from .help import help` | Ídem Bug 4 |
-| 7 | `OtherViews/otherViews.py` | Mismo problema: `from .help import help` | Ídem Bug 4 |
-| 8 | `Dimensions/dimensions.py` | Usa `dimensions['angle'] = angle` para agregar el sub-dict ángulo — inconsistente con el resto que usa `.update()` | Cambiar a `dimensions.update(angle)` |
-| 9 | `Dimensions/dimension/dimension.py` | Usa `"TechDraw::DrawDimLine"` como tipo de objeto — ese tipo no existe en FreeCAD 1.x (la API correcta es `TechDraw_LengthDimension` vía `Gui.runCommand` o el tipo `TechDraw::DrawViewDimension`) | Cambiar a `Gui.runCommand('TechDraw_LengthDimension', 0)` o corregir el tipo de objeto |
-| 10 | `Snaps/Snaps.py` | Sin clave `'help'` — único sub-módulo activo que no expone ayuda | Agregar `from ..ayuda import ayuda` y `snaps['help'] = ayuda` |
-| 11 | `Topology/Topology.py` | Sin clave `'help'` — mismo problema que Bug 10 | Agregar ayuda |
-| 12 | `Features/Features.py` | Sin clave `'help'` | Agregar ayuda |
-| 13 | `Symbols/Symbols.py` | Claves `'weldSymbol'` y `'richText'` usan camelCase — viola convención del proyecto (sin separadores, todo minúscula) | Renombrar a `'weldsymbol'`, `'richtext'`, `'finish'` (ya ok) |
-| 14 | `AddLines/addLines.py` | Claves `'twoLines'` y `'twoPoints'` usan camelCase | Renombrar a `'twolines'`, `'twopoints'` |
-| 15 | `Views/Views.py` | Claves `'detailView'`, `'brokenView'`, `'clipGroup'`, `'complexSection'` usan camelCase | Renombrar a `'detailview'`, `'brokenview'`, `'clipgroup'`, `'complexsection'` |
+> Estado verificado el 2026-06-25 contra el código real (`TechDraw.py`).
+
+| # | Archivo | Problema | Estado |
+|---|---------|----------|--------|
+| 1 | `TechDraw.py` | No importaba `Page`, `Annotations`, `Hatching`, `AddVertices`, `OtherViews`, `Features` | ✅ Corregido — los 12 submódulos importados |
+| 2 | `Views/view.py` | Archivo huérfano | ✅ Resuelto — eliminado (queda `Views.py`) |
+| 3 | `Symbols/weld.py` | Duplica `TechDraw_WeldSymbol` | ✅ Resuelto — eliminado |
+| 4 | `Annotations/annotations.py` | `from .help import help` (inglés) | ⚠️ Parcial — existe `ayuda.py` pero **el `help.py` sigue presente** (leftover a eliminar) |
+| 5 | `Hatching/hatching.py` | `from .help import help` | ⚠️ Parcial — `ayuda.py` existe pero `help.py` sigue presente |
+| 6 | `AddVertices/addVertices.py` | `from .help import help` | ⚠️ Parcial — `ayuda.py` existe pero `help.py` sigue presente |
+| 7 | `OtherViews/otherViews.py` | `from .help import help` | ⚠️ Parcial — `ayuda.py` existe pero `help.py` sigue presente |
+| 8 | `Dimensions/dimensions.py` | Usa `dimensions['angle'] = angle` en vez de `.update(angle)` | ⚠️ **Pendiente** — sigue usando asignación directa |
+| 9 | `Dimensions/dimension/dimension.py` | `"TechDraw::DrawDimLine"` — tipo inexistente en FreeCAD 1.x | ✅ Corregido — usa `Gui.runCommand('TechDraw_LengthDimension', 0)` |
+| 10 | `Snaps/Snaps.py` | Sin clave `'help'` | ✅ Corregido — expone `'help': ayuda` |
+| 11 | `Topology/Topology.py` | Sin clave `'help'` | ✅ Corregido — expone `'help': ayuda` |
+| 12 | `Features/Features.py` | Sin clave `'help'` | ✅ Corregido — expone `'help': ayuda` |
+| 13 | `Symbols/Symbols.py` | Claves camelCase `'weldSymbol'`, `'richText'` | ✅ Corregido — `'weldsymbol'`, `'richtext'`, `'finish'` |
+| 14 | `AddLines/addLines.py` | Claves camelCase `'twoLines'`, `'twoPoints'` | ✅ Corregido — `'twolines'`, `'twopoints'` |
+| 15 | `Views/Views.py` | Claves camelCase `'detailView'`, etc. | ✅ Corregido — `'detailview'`, `'brokenview'`, `'clipgroup'`, `'complexsection'` |
+| 16 | `TechDraw.py` | Clave de ayuda raíz es `'ayuda'` (español) — inconsistente con `'help'` que usan los demás roots y CONTEXT.md | ⚠️ **Pendiente** (nuevo) — cambiar a `'help'` |
+| 17 | `Topology/Topology.py` | Clave `'showAll'` usa camelCase | ⚠️ **Pendiente** (nuevo) — renombrar a `'showall'` |
 
 ### LineAttributes (sub-módulo TechDraw)
 
@@ -525,7 +541,7 @@ Los 2 tickets de LineAttributes corresponden al TechDraw Workbench (`TechDraw_Ex
 
 ```text
 Workbench/Part/
-├── PartWorkbench.py              ← raíz, usa .update() — importa los 24 sub-dicts
+├── Part.py                       ← raíz, usa .update() — importa los 24 sub-dicts (clave de ayuda raíz: 'ayuda')
 ├── box/box.py                    ✅
 ├── circle/circle.py              ✅
 ├── cone/cone.py                  ✅
@@ -598,11 +614,13 @@ Workbench/Part/
 
 ## Resumen general de cobertura
 
+> Actualizado 2026-06-25 tras contrastar con el código real.
+
 | Módulo | Tickets | Cubiertos | Faltantes | Estado |
 |--------|---------|-----------|-----------|--------|
 | Assembly | 22 | 22 | 0 | ✅ Completo |
-| DraftWork | 59 | 45 activos + 14 inactivos | 1 (`Draft_Line`) | ⚠️ Bugs estructurales |
+| DraftWork | 59 | 59 activos (todos importados) | 1 (`Draft_Line`) | ⚠️ Falta nomenclatura en `modification.py` |
 | PartDesign | 36 | 36 | 0 | ✅ Completo (con duplicados) |
-| Sketcher | 97 | 94 | 1 (`refraction`) + 2 no aplica | ✅ Casi completo |
-| Part | 24 sub-dicts, todos activos | 24 | 0 (todos tienen archivo) | ❌ Bugs de implementación graves |
-| TechDraw | 29 activos + 15 inactivos | 29 | 0 (todos tienen archivo) | ⚠️ Bugs estructurales y de nomenclatura |
+| Sketcher | 97 | 94 | 1 (`refraction`) + 2 no aplica | ⚠️ Casi completo |
+| Part | 24 sub-dicts, todos activos | 24 | 0 | ⚠️ Funcional (Opción B); falta limpieza de claves |
+| TechDraw | 44 activos (todos importados) | 44 | 0 | ⚠️ Funcional; falta limpieza menor (`'ayuda'` raíz, `'showAll'`, leftovers `help.py`) |


### PR DESCRIPTION
## Resumen

Reconcilia los `Dav/dic/AVANCES_*.md` (fechados 2026-06-03) con el estado real del código, que cambió después de esa revisión. No se modifica código de diccionarios, solo documentación.

## Diferencias detectadas y documentadas

**Arquitectura no documentada antes**
- `_lenient.LenientDict` aplicado en `DraftWork.py` y `Dimensions/dimensions.py`.
- Explorer pasó de aplanado (`.update()`) a **subcontextos anidados** (`explorer['file']`, `explorer['edit']`…); los bugs de colisión por aplanamiento ya no aplican.
- Nombres de archivo raíz corregidos (`DraftWork.py`, `Part.py`, `TechDraw.py`, `StructureToolbar.py`, `circular_array.py`).

**Bugs que la doc daba como pendientes y ya estaban corregidos en código**
- DraftWork: imports huérfanos, typo `FreeCad`→`FreeCADGui`, carpetas `snap/` y `modification/array/` eliminadas, `shapestring`, `pathlink`/`pointlink`.
- TechDraw: 12 submódulos importados; camelCase corregido en Views/AddLines/Symbols; `dimension.py` usa `TechDraw_LengthDimension`; help keys agregadas.

**Bugs que siguen presentes (verificados en código)**
- Sketcher: falta `'refraction'`.
- DraftWork `modification.py`: guiones bajos + sin cabezal GPL.
- TechDraw/Part roots usan `'ayuda'` en vez de `'help'`; `dimensions['angle']=angle`; `'showAll'` camelCase; leftovers `help.py`.
- Explorer: `AdditionalTools/Additional.py` (`linkgroups`) quedó huérfano.

**Sin cambios** — StdView y LineAttributes coinciden con el código (solo nota de reconfirmación).

## Archivos
- `Dav/dic/AVANCES_GENERAL.md`
- `Dav/dic/AVANCES_WORKBENCH.md`
- `Dav/dic/AVANCES_EXPLORER.md`
- `Dav/dic/AVANCES_STDVIEW.md`
- `Dav/dic/AVANCES_LINEATTRIBUTES.md`