### PR TITLE
fix(dic): resolver conflictos git y agregar test de integración para …

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,27 @@
+# Instructions and Project Rules for DAV Agents
+
+## Mandatory Convention: Nested Subcontexts (Rule 4)
+
+When assembling the master dictionary of any folder in `Dav/dic/`, every submenu MUST be added as a nested dictionary under its own dedicated key, NEVER merged directly via `.update(sub_dict)`:
+
+### Correct Pattern (Reference: `Explorer/Explorer.py`)
+```python
+explorer.update({'file': file})
+explorer.update({'edit': edit})
+```
+
+### Incorrect Pattern (Flattens child leaves into parent)
+```python
+# DO NOT DO THIS — flattens child leaves into parent
+explorer.update(file)
+explorer.update(edit)
+```
+
+### Why it Matters:
+1. **Silent Key Collisions**: Multiple sub-dictionaries define common key names (`create`, `help`, `center`, `horizontal`). Using direct `.update(sub_dict)` causes later submenus to silently overwrite earlier keys.
+2. **Orphaned Translations**: `DictionaryLoader` loads `TraduceTo*.py` for a folder ONLY when `Browser` descends to that folder as a frame. If a parent flattens the child, the folder is lost as a navigable node in the stack, and its translation file is never loaded even if correctly written.
+
+### New Workbench / Submenu Checklist:
+- Always nest sub-dictionaries using `parent_dict.update({'submenu_key': submenu_dict})`.
+- Ensure the folder remains navigable so `Browser` can descend and `DictionaryLoader` reads its `TraduceTo*.py`.
+- Run integration tests to verify AST adherence: `Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/.venv/Scripts/python.exe -m unittest Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/tests/test_real_dictionaries.py`.

--- a/Dav/dic/Workbench/DraftWork/dimension/TraduceToPt.py
+++ b/Dav/dic/Workbench/DraftWork/dimension/TraduceToPt.py
@@ -27,13 +27,7 @@ TraduceToPt = {
     "inverter": dimension["flip"],
     "espelhar dimensão": dimension["flip"],
 
-<<<<<<< HEAD
     "ajuda":             dimension["help"],
     "informação":        dimension["help"],
-    "opções":            dimension["help"]
-=======
-    "ajuda": dimension["help"],
-    "informação": dimension["help"],
-    "opções": dimension["help"],
->>>>>>> ab0008d5c571ed323a300c3168bedfe72882654d
+    "opções":            dimension["help"],
 }

--- a/Dav/dic/Workbench/DraftWork/modify/TraduceToPt.py
+++ b/Dav/dic/Workbench/DraftWork/modify/TraduceToPt.py
@@ -54,13 +54,8 @@ TraduceToPt = {
     "espelho": modify["mirror"],
     "refletir": modify["mirror"],
 
-<<<<<<< HEAD
+    "help":              modify["help"],
     "ajuda":             modify["help"],
-    "informação":       modify["help"],
-    "opções":            modify["help"]
-=======
-    "help": modify["help"],
-    "ajuda": modify["help"],
-    "opções": modify["help"],
->>>>>>> ab0008d5c571ed323a300c3168bedfe72882654d
+    "informação":        modify["help"],
+    "opções":            modify["help"],
 }

--- a/Dav/dic/Workbench/Part/circle/TraduceToPt.py
+++ b/Dav/dic/Workbench/Part/circle/TraduceToPt.py
@@ -23,17 +23,9 @@ TraduceToPt = {
     'circulo':  circle['circle'],
     'círculo':  circle['circle'],
     'redondo':  circle['circle'],
-<<<<<<< Updated upstream
-    
-    "ajuda":             circle['help'],
-    "informação":       circle['help'],
-    "opções":            circle['help']
-}
-=======
-    'roda':     circle['circle'],
+    'roda':              circle['circle'],
     'desenhar círculo': circle['circle'],
-    "ajuda":             circle["help"],
-    "informação":       circle["help"],
-    "opções":            circle["help"]
+    "ajuda":             circle['help'],
+    "informação":        circle['help'],
+    "opções":            circle['help'],
 }
->>>>>>> Stashed changes

--- a/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/tests/test_browser.py
+++ b/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/tests/test_browser.py
@@ -45,6 +45,20 @@ def _install_freecad_stub() -> None:
         sys.modules["FreeCADGui"] = gui
     if "FreeCAD" not in sys.modules:
         sys.modules["FreeCAD"] = types.ModuleType("FreeCAD")
+    app = sys.modules["FreeCAD"]
+    if not hasattr(app, "ActiveDocument"):
+        app.ActiveDocument = None
+    class Vector:
+        def __init__(self, *args, **kwargs): pass
+    class Placement:
+        def __init__(self, *args, **kwargs): pass
+    class Rotation:
+        def __init__(self, *args, **kwargs): pass
+    class Matrix:
+        def __init__(self, *args, **kwargs): pass
+    for attr, cls in [("Vector", Vector), ("Placement", Placement), ("Rotation", Rotation), ("Matrix", Matrix)]:
+        if not hasattr(app, attr):
+            setattr(app, attr, cls)
 
 
 # ---------------------------------------------------------------------------

--- a/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/tests/test_real_dictionaries.py
+++ b/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/tests/test_real_dictionaries.py
@@ -1,0 +1,150 @@
+#  Copyright (C) 2026 The DAV Project Team
+#  Universidad Autónoma de Entre Ríos (UADER)
+#  SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Integration tests for real dictionary hierarchy (Dav/dic).
+
+Enforces Rule 4 (Nested subcontexts convention):
+- Submenus MUST be nested under their own key (e.g. explorer.update({'file': file})).
+- Submenus MUST NOT be flattened (e.g. explorer.update(file) is forbidden).
+- Ensures no dead code overrides dictionary updates.
+- Verifies base.py loads cleanly and subfolders remain navigable.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+
+GUI_ROOT = Path(__file__).resolve().parents[1]
+if str(GUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(GUI_ROOT))
+
+from integration.dav_paths import dav_repo_root, ensure_dav_repo_on_path  # noqa: E402
+
+ensure_dav_repo_on_path()
+DAV_DIR = dav_repo_root().parent
+DIC_ROOT = DAV_DIR / "dic"
+
+if str(DIC_ROOT) not in sys.path:
+    sys.path.insert(0, str(DIC_ROOT))
+
+
+def _install_freecad_stub() -> None:
+    if "FreeCADGui" not in sys.modules:
+        gui = types.ModuleType("FreeCADGui")
+        gui.runCommand = lambda name, idx=0: None  # type: ignore[attr-defined]
+        sys.modules["FreeCADGui"] = gui
+    if "FreeCAD" not in sys.modules:
+        sys.modules["FreeCAD"] = types.ModuleType("FreeCAD")
+    app = sys.modules["FreeCAD"]
+    if not hasattr(app, "ActiveDocument"):
+        app.ActiveDocument = None
+    class Vector:
+        def __init__(self, *args, **kwargs): pass
+    class Placement:
+        def __init__(self, *args, **kwargs): pass
+    class Rotation:
+        def __init__(self, *args, **kwargs): pass
+    class Matrix:
+        def __init__(self, *args, **kwargs): pass
+    for attr, cls in [("Vector", Vector), ("Placement", Placement), ("Rotation", Rotation), ("Matrix", Matrix)]:
+        if not hasattr(app, attr):
+            setattr(app, attr, cls)
+    for mod in ("Part", "PartDesign", "Sketcher", "Draft", "TechDraw", "Assembly", "Mesh", "Fem"):
+        if mod not in sys.modules:
+            sys.modules[mod] = types.ModuleType(mod)
+
+
+class TestRealDictionariesConvention(unittest.TestCase):
+    """Audits Dav/dic for mandatory nesting convention and navigation integrity."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        _install_freecad_stub()
+
+    def test_no_flattened_updates_in_dic(self) -> None:
+        """
+        Rule 4: Verify that no .update() call in Dav/dic flattens a sub-dictionary.
+        All update calls must pass a dict literal mapping a key string to a sub-dict,
+        e.g., dict.update({'key': sub_dict}).
+        """
+        violations: list[str] = []
+
+        for root, _, files in os.walk(DIC_ROOT):
+            for file in files:
+                if not file.endswith(".py"):
+                    continue
+                filepath = Path(root) / file
+                with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
+                    source = f.read()
+
+                try:
+                    tree = ast.parse(source, filename=str(filepath))
+                except SyntaxError as e:
+                    violations.append(f"Syntax error in {filepath}: {e}")
+                    continue
+
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                        call = node.value
+                        if isinstance(call.func, ast.Attribute) and call.func.attr == "update":
+                            if len(call.args) == 1:
+                                arg = call.args[0]
+                                # If argument is a variable/name or call instead of a dict literal {}, record violation
+                                if not isinstance(arg, ast.Dict):
+                                    rel_path = filepath.relative_to(DIC_ROOT)
+                                    violations.append(
+                                        f"{rel_path}:{node.lineno} -> {ast.unparse(call)} "
+                                        f"(Flattened update! Must wrap in dict literal like update({{'key': sub_dict}}))"
+                                    )
+
+        self.assertEqual(
+            violations,
+            [],
+            "Found flattened .update(...) calls violating Rule 4:\n" + "\n".join(violations),
+        )
+
+    def test_base_py_imports_and_has_top_level_keys(self) -> None:
+        """Verify that base.py loads clean top level dictionaries."""
+        from navigation.dictionary_loader import DictionaryLoader
+
+        loader = DictionaryLoader(DIC_ROOT)
+        self.assertTrue(loader.IsReady, f"DictionaryLoader should find DIC_ROOT at {DIC_ROOT}")
+
+        base_dict = loader.LoadBaseModuleDict()
+        self.assertIn("explorer", base_dict)
+        self.assertIn("stdview", base_dict)
+        self.assertIn("workbench", base_dict)
+        self.assertIn("lineattributes", base_dict)
+        self.assertIn("preferences", base_dict)
+
+    def test_top_level_workbenches_are_nested(self) -> None:
+        """Verify that workbench.py contains nested workbenches as subcontext dicts."""
+        from navigation.dictionary_loader import DictionaryLoader
+
+        loader = DictionaryLoader(DIC_ROOT)
+        base_dict = loader.LoadBaseModuleDict()
+        workbench = base_dict.get("workbench", {})
+
+        expected_submenus = ["assembly", "draft", "part", "partdesign", "sketcher", "techdraw"]
+        for submenu in expected_submenus:
+            self.assertIn(
+                submenu,
+                workbench,
+                f"Workbench missing nested key '{submenu}'. Check workbench.py nesting!",
+            )
+            self.assertIsInstance(
+                workbench[submenu],
+                dict,
+                f"workbench['{submenu}'] should be a dict subcontext, got {type(workbench[submenu])}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…subcontextos anidados

- Resolver marcadores de conflicto no resueltos en archivos TraduceToPt.py (dimension, modify y circle).
- Agregar test de integración 'test_real_dictionaries.py' para validar por AST el anidamiento obligatorio de subcontextos (Regla 4) y la navegabilidad del árbol.
- Hacer más robustos los stubs de FreeCAD en los unit tests para ejecutar pruebas sin interfaz gráfica.
- Registrar la convención de subcontextos anidados en '.agents/AGENTS.md'.