### PR TITLE
fix: corregir la firma de CreateObjects en los diccionarios de DraftWork

### DIFF
--- a/Dav/dic/Workbench/DraftWork/Drafting/drafting.py
+++ b/Dav/dic/Workbench/DraftWork/Drafting/drafting.py
@@ -19,7 +19,7 @@ def create_wire_objects():
         return
 
     obj = doc.ActiveObject
-    CreateObjects(obj.Name, Is3D=False).execute()
+    CreateObjects(ObjectName=obj.Name, Is3D=False).Execute()
 
 
 drafting = {

--- a/Dav/dic/Workbench/DraftWork/annotation/annotation.py
+++ b/Dav/dic/Workbench/DraftWork/annotation/annotation.py
@@ -10,17 +10,23 @@ from .ayuda import ayuda
 
 def text():
     Gui.runCommand("Draft_Text", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def shapestring():
     Gui.runCommand("Draft_ShapeString", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def label():
     Gui.runCommand("Draft_Label", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 annotation = {

--- a/Dav/dic/Workbench/DraftWork/arc/arc.py
+++ b/Dav/dic/Workbench/DraftWork/arc/arc.py
@@ -10,12 +10,16 @@ from .ayuda import ayuda
 
 def center():
     Gui.runCommand("Draft_Arc", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def points():
     Gui.runCommand("Draft_Arc_3Points", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 arc = {

--- a/Dav/dic/Workbench/DraftWork/circle/circle.py
+++ b/Dav/dic/Workbench/DraftWork/circle/circle.py
@@ -10,8 +10,9 @@ from .ayuda import ayuda
 def center():
     Gui.runCommand("Draft_Circle", 0)
 
-    obj = App.ActiveDocument.ActiveObject
-    CreateObjects(Is3D=False).Execute(obj)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 circle = {
     "center": center,

--- a/Dav/dic/Workbench/DraftWork/creation/creation.py
+++ b/Dav/dic/Workbench/DraftWork/creation/creation.py
@@ -26,17 +26,23 @@ from .ayuda import ayuda
 
 def point():
     Gui.runCommand("Draft_Point", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def polygon():
     Gui.runCommand("Draft_Polygon", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def rectangle():
     Gui.runCommand("Draft_Rectangle", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 creation = {

--- a/Dav/dic/Workbench/DraftWork/curve/curve.py
+++ b/Dav/dic/Workbench/DraftWork/curve/curve.py
@@ -10,17 +10,23 @@ from .ayuda import ayuda
 
 def bezier():
     Gui.runCommand("Draft_BezCurve", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def bspline():
     Gui.runCommand("Draft_BSpline", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def cubic():
     Gui.runCommand("Draft_CubicBezCurve", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 curve = {

--- a/Dav/dic/Workbench/DraftWork/dimension/dimension.py
+++ b/Dav/dic/Workbench/DraftWork/dimension/dimension.py
@@ -10,7 +10,9 @@ from .ayuda import ayuda
 
 def linear():
     Gui.runCommand("Draft_Dimension", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 dimension = {

--- a/Dav/dic/Workbench/DraftWork/ellipse/ellipse.py
+++ b/Dav/dic/Workbench/DraftWork/ellipse/ellipse.py
@@ -10,7 +10,9 @@ from .ayuda import ayuda
 
 def center():
     Gui.runCommand("Draft_Ellipse", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 ellipse = {

--- a/Dav/dic/Workbench/DraftWork/facebinder/facebinder.py
+++ b/Dav/dic/Workbench/DraftWork/facebinder/facebinder.py
@@ -10,7 +10,9 @@ from .ayuda import ayuda
 
 def create():
     Gui.runCommand("Draft_Facebinder", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 facebinder = {

--- a/Dav/dic/Workbench/DraftWork/modification/modification.py
+++ b/Dav/dic/Workbench/DraftWork/modification/modification.py
@@ -10,12 +10,16 @@ from .ayuda import ayuda
 
 def shape_2d_view():
     Gui.runCommand("Draft_Shape2DView", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def wire_to_bspline():
     Gui.runCommand("Draft_WireToBSpline", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 modification = {

--- a/Dav/dic/Workbench/DraftWork/modify/modify.py
+++ b/Dav/dic/Workbench/DraftWork/modify/modify.py
@@ -10,17 +10,23 @@ from .ayuda import ayuda
 
 def clone():
     Gui.runCommand("Draft_Clone", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def sketch():
     Gui.runCommand("Draft_Draft2Sketch", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 def offset():
     Gui.runCommand("Draft_Offset", 0)
-    CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
 
 modify = {


### PR DESCRIPTION
Las 21 llamadas a `CreateObjects` de `DraftWork/` usaban una firma que no existe. La clase pide `ObjectName` como argumento obligatorio y `Execute()` no recibe argumentos ([`Dav/scr/selection/createobjects.py`](https://github.com/DAv-Project-Team-UADER/DAV/blob/DavCore/Dav/scr/selection/createobjects.py)):

```python
def __init__(self, ObjectName: str, Is3D: bool = False, *, ...)
def Execute(self) -> None
```

Lo que había en `DraftWork/` era:

```python
CreateObjects(Is3D=False).Execute(App.ActiveDocument.ActiveObject)
```

Ninguna de esas llamadas podía ejecutarse: falta el argumento obligatorio `ObjectName` y sobra el que se le pasa a `Execute()`, así que cualquier comando de voz de Draft que llegara a `CreateObjects` cortaba con `TypeError`. Los 9 archivos que resolvían el objeto inline con `App.ActiveDocument.ActiveObject` fallaban antes todavía, con `AttributeError`, si no había documento abierto.

## Qué cambia

Se unifican las 21 llamadas al patrón que ya usan `Sketcher/`, `Part/` y `PartDesign/`, que es el correcto y además chequea el documento activo:

```python
active_doc = App.ActiveDocument
if active_doc and active_doc.ActiveObject:
    CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
```

Dos casos salían del molde y se corrigieron aparte:

- `circle/circle.py` resolvía el objeto en una variable previa, sin chequeo.
- `Drafting/drafting.py` ya pasaba bien el nombre y chequeaba el documento, pero llamaba a `.execute()` en minúscula; el método es `Execute`.

## Alcance

11 archivos, 21 llamadas: `annotation`, `creation`, `curve`, `modify` (3 c/u), `arc`, `modification` (2 c/u), `dimension`, `ellipse`, `facebinder`, `circle`, `Drafting` (1 c/u).

Los archivos de `Sketcher/`, `Part/` y `PartDesign/` ya estaban bien y no se tocaron.

## Verificación

- `python -m py_compile` sobre los 11 archivos: OK.
- Barrido posterior: no quedan llamadas con la firma vieja en `Dav/dic/`.
- Firma validada por AST contra la clase real: `__init__` acepta `ObjectName`/`Is3D`, `Execute` solo `self`.

No pude probarlo dentro de FreeCAD, así que la ejecución real de los comandos de voz de Draft conviene confirmarla en el entorno.