### PR TITLE
Adición de traduceTo faltantes en la carpeta arcslot

### DIFF
--- a/Dav/dic/StdView/StandardViews/TraduceToEn.py
+++ b/Dav/dic/StdView/StandardViews/TraduceToEn.py
@@ -20,7 +20,7 @@ from .ayuda import ayuda
 
 from .StandardViews import StandardViews
 
-TranslateToEn = {
+TraducteToEn = {
     # Bottom
     'bottom': StandardViews['bottom'],
     'below': StandardViews['bottom'],

--- a/Dav/dic/Workbench/PartDesign/additive/TraduceToEn.py
+++ b/Dav/dic/Workbench/PartDesign/additive/TraduceToEn.py
@@ -18,7 +18,7 @@
 import additive as additive
 import ayuda as ayuda
 
-traduceToEn = {
+TraduceToEn = {
     # Pad
     "pad": additive["pad"],
     "pad feature": additive["pad"],

--- a/Dav/dic/Workbench/Sketcher/TraduceToPt.py
+++ b/Dav/dic/Workbench/Sketcher/TraduceToPt.py
@@ -24,7 +24,7 @@ from .sketcher import _toggle_construction
 from .ayuda import ayuda as sketcher_ayuda
 from .sketcher import sketcher
 
-TranslateToPt = {
+TraduceToPt = {
   
   # Carpetas de Sketcher  
   "geometria": sketcher["geometry"],

--- a/Dav/dic/Workbench/Sketcher/arcslot/TraduceToEn.py
+++ b/Dav/dic/Workbench/Sketcher/arcslot/TraduceToEn.py
@@ -15,3 +15,26 @@
 # Deberías haber recibido una copia de la Licencia Pública General GNU
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from arcslot import arc_slot
+
+TraduceToEn = {
+    # Arc Slot with Arc Ends
+    "arc slot":         arc_slot["arcends"],
+    "curved ends":      arc_slot["arcends"],
+    "rounded slot":     arc_slot["arcends"],
+    "slot with arcs":   arc_slot["arcends"],
+    "arcends":          arc_slot["arcends"],
+
+    # Arc Slot with Flat Ends
+    "flat slot":        arc_slot["flatends"],
+    "straight ends":    arc_slot["flatends"],
+    "rectangular slot": arc_slot["flatends"],
+    "slot with flats":  arc_slot["flatends"],
+    "flatends":         arc_slot["flatends"],
+
+    # Help
+    "help":             arc_slot["help"],
+    "info":             arc_slot["help"],
+    "options":          arc_slot["help"]
+}

--- a/Dav/dic/Workbench/Sketcher/arcslot/TraduceToEs.py
+++ b/Dav/dic/Workbench/Sketcher/arcslot/TraduceToEs.py
@@ -15,3 +15,26 @@
 # Deberías haber recibido una copia de la Licencia Pública General GNU
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from arcslot import arc_slot
+
+TraduceToEs = {
+    # Ranura con extremos curvos
+    "ranura arco":      arc_slot["arcends"],
+    "extremos curvos":  arc_slot["arcends"],
+    "ranura redondeada":arc_slot["arcends"],
+    "slot con arcos":   arc_slot["arcends"],
+    "arcends":          arc_slot["arcends"],
+
+    # Ranura con extremos planos
+    "ranura plana":     arc_slot["flatends"],
+    "extremos rectos":  arc_slot["flatends"],
+    "ranura rectangular": arc_slot["flatends"],
+    "slot con planos":  arc_slot["flatends"],
+    "flatends":         arc_slot["flatends"],
+
+    # Ayuda
+    "ayuda":            arc_slot["help"],
+    "información":      arc_slot["help"],
+    "opciones":         arc_slot["help"]
+}

--- a/Dav/dic/Workbench/Sketcher/arcslot/TraduceToPt.py
+++ b/Dav/dic/Workbench/Sketcher/arcslot/TraduceToPt.py
@@ -15,3 +15,26 @@
 # Deberías haber recibido una copia de la Licencia Pública General GNU
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from arcslot import arc_slot
+
+TraduceToPt = {
+    # Fenda com extremidades curvas
+    "ranhura arco":     arc_slot["arcends"],
+    "extremos curvos":  arc_slot["arcends"],
+    "ranhura arredondada": arc_slot["arcends"],
+    "slot com arcos":   arc_slot["arcends"],
+    "arcends":          arc_slot["arcends"],
+
+    # Fenda com extremidades planas
+    "ranhura plana":    arc_slot["flatends"],
+    "extremos retos":   arc_slot["flatends"],
+    "ranhura retangular": arc_slot["flatends"],
+    "slot com planos":  arc_slot["flatends"],
+    "flatends":         arc_slot["flatends"],
+
+    # Ajuda
+    "ajuda":            arc_slot["help"],
+    "informações":      arc_slot["help"],
+    "opções":           arc_slot["help"]
+}


### PR DESCRIPTION
Se agregaron diccionarios que se encontraban vacios y se corrigieron algunos errores de consistencia.
