### PR TITLE
Implementación y fix de comandos de voz para TechDraw

### DIFF
--- a/Dav/dic/Workbench/TechDraw/AddVertices/addVertices.py
+++ b/Dav/dic/Workbench/TechDraw/AddVertices/addVertices.py
@@ -18,7 +18,14 @@
 import FreeCADGui as Gui
 from .ayuda import ayuda
 
+def run_cmd(cmd):
+    try:
+        Gui.activateWorkbench("TechDrawWorkbench")
+        Gui.runCommand(cmd, 0)
+    except Exception as e:
+        print(f"[DAV] Error: {e}")
+
 add_vertices = {
-    'cosmetic': lambda: Gui.runCommand('TechDraw_CosmeticVertex', 0),
+    'cosmetic': lambda: run_cmd('TechDraw_CosmeticVertex'),
     'help': ayuda
 }

--- a/Dav/dic/Workbench/TechDraw/Annotations/annotations.py
+++ b/Dav/dic/Workbench/TechDraw/Annotations/annotations.py
@@ -18,9 +18,16 @@
 import FreeCADGui as Gui
 from .ayuda import ayuda
 
+def run_cmd(cmd):
+    try:
+        Gui.activateWorkbench("TechDrawWorkbench")
+        Gui.runCommand(cmd, 0)
+    except Exception as e:
+        print(f"[DAV] Error: {e}")
+
 annotations = {
-    'annotation': lambda: Gui.runCommand('TechDraw_Annotation', 0),
-    'axo_length': lambda: Gui.runCommand('TechDraw_AxoLengthDimension', 0),
-    'balloon': lambda: Gui.runCommand('TechDraw_Balloon', 0),
+    'annotation': lambda: run_cmd('TechDraw_Annotation'),
+    'axo_length': lambda: run_cmd('TechDraw_AxoLengthDimension'),
+    'balloon': lambda: run_cmd('TechDraw_Balloon'),
     'help': ayuda
 }

--- a/Dav/dic/Workbench/TechDraw/Page/Page.py
+++ b/Dav/dic/Workbench/TechDraw/Page/Page.py
@@ -18,12 +18,19 @@ import FreeCADGui as Gui
 from .ayuda import ayuda
 
 # Diccionario del subgrupo Page (Gestión de lienzos de planos y salidas)
+def run_cmd(cmd):
+    try:
+        Gui.activateWorkbench("TechDrawWorkbench")
+        Gui.runCommand(cmd, 0)
+    except Exception as e:
+        print(f"[DAV] Error: {e}")
+
 page = {
-    'default': lambda: Gui.runCommand('TechDraw_PageDefault', 0),
-    'template': lambda: Gui.runCommand('TechDraw_PageTemplate', 0),
-    'redraw': lambda: Gui.runCommand('TechDraw_RedrawPage', 0),
-    'print': lambda: Gui.runCommand('TechDraw_PrintAll', 0),
-    'dxf': lambda: Gui.runCommand('TechDraw_ExportPageDXF', 0),
-    'svg': lambda: Gui.runCommand('TechDraw_ExportPageSVG', 0),
+    'default': lambda: run_cmd('TechDraw_PageDefault'),
+    'template': lambda: run_cmd('TechDraw_PageTemplate'),
+    'redraw': lambda: run_cmd('TechDraw_RedrawPage'),
+    'print': lambda: run_cmd('TechDraw_PrintAll'),
+    'dxf': lambda: run_cmd('TechDraw_ExportPageDXF'),
+    'svg': lambda: run_cmd('TechDraw_ExportPageSVG'),
     'help': ayuda
 }

--- a/Dav/dic/Workbench/TechDraw/Symbols/Symbols.py
+++ b/Dav/dic/Workbench/TechDraw/Symbols/Symbols.py
@@ -14,9 +14,16 @@
 import FreeCADGui as Gui
 from .ayuda import ayuda
 
+def run_cmd(cmd):
+    try:
+        Gui.activateWorkbench("TechDrawWorkbench")
+        Gui.runCommand(cmd, 0)
+    except Exception as e:
+        print(f"[DAV] Error: {e}")
+
 symbols = {
-    'weldsymbol': lambda: Gui.runCommand('TechDraw_WeldSymbol', 0),
-    'richtext': lambda: Gui.runCommand('TechDraw_RichTextAnnotation', 0),
-    'finish': lambda: Gui.runCommand('TechDraw_SurfaceFinishSymbols', 0),
+    'weldsymbol': lambda: run_cmd('TechDraw_WeldSymbol'),
+    'richtext': lambda: run_cmd('TechDraw_RichTextAnnotation'),
+    'finish': lambda: run_cmd('TechDraw_SurfaceFinishSymbols'),
     'help': ayuda
 }

--- a/Dav/dic/Workbench/TechDraw/Views/Views.py
+++ b/Dav/dic/Workbench/TechDraw/Views/Views.py
@@ -14,13 +14,20 @@
 import FreeCADGui as Gui
 from .ayuda import ayuda
 
+def run_cmd(cmd):
+    try:
+        Gui.activateWorkbench("TechDrawWorkbench")
+        Gui.runCommand(cmd, 0)
+    except Exception as e:
+        print(f"[DAV] Error: {e}")
+
 views = {
-    'view': lambda: Gui.runCommand('TechDraw_View', 0),
-    'detailview': lambda: Gui.runCommand('TechDraw_DetailView', 0),
-    'brokenview': lambda: Gui.runCommand('TechDraw_BrokenView', 0),
-    'clipgroup': lambda: Gui.runCommand('TechDraw_ClipGroup', 0),
-    'complexsection': lambda: Gui.runCommand('TechDraw_ComplexSection', 0),
-    'draft': lambda: Gui.runCommand('TechDraw_DraftView', 0),
-    'spreadsheet': lambda: Gui.runCommand('TechDraw_SpreadsheetView', 0),
+    'view': lambda: run_cmd('TechDraw_View'),
+    'detailview': lambda: run_cmd('TechDraw_DetailView'),
+    'brokenview': lambda: run_cmd('TechDraw_BrokenView'),
+    'clipgroup': lambda: run_cmd('TechDraw_ClipGroup'),
+    'complexsection': lambda: run_cmd('TechDraw_ComplexSection'),
+    'draft': lambda: run_cmd('TechDraw_DraftView'),
+    'spreadsheet': lambda: run_cmd('TechDraw_SpreadsheetView'),
     'help': ayuda
 }


### PR DESCRIPTION
Se agregaron los wrappers con Gui.activateWorkbench('TechDrawWorkbench') en Views, Annotations, Symbols y Page para evitar que FreeCAD arroje el error 'No such command' al usar la voz con un inicio limpio