### PR TITLE
PartDesign: extruir por voz (pad, caja, cilindro y revolucion por medida dictada)

### DIFF
--- a/Dav/dic/Workbench/PartDesign/additive/TraduceToEn.py
+++ b/Dav/dic/Workbench/PartDesign/additive/TraduceToEn.py
@@ -15,10 +15,10 @@
 # Deberías haber recibido una copia de la Licencia Pública General GNU
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
-import additive as additive
-import ayuda as ayuda
+from .additive import additive
+from .ayuda import ayuda
 
-traduceToEn = {
+TraduceToEn = {
     # Pad
     "pad": additive["pad"],
     "pad feature": additive["pad"],
@@ -81,6 +81,29 @@ traduceToEn = {
     "sweep surfaces": additive["loft_profiles"],
     "morph sections": additive["loft_profiles"],
 
+
+
+    # Pad by dictated length (no dialog)
+    "pad by length": additive["pad_by_length"],
+    "extrude by length": additive["pad_by_length"],
+    "extrude by height": additive["pad_by_length"],
+    "give height": additive["pad_by_length"],
+
+    # Box by dictated dimensions
+    "box by size": additive["box_by_size"],
+    "cube by size": additive["box_by_size"],
+    "create box by size": additive["box_by_size"],
+    "box by dimensions": additive["box_by_size"],
+
+    # Cylinder by dictated dimensions
+    "cylinder by size": additive["cylinder_by_size"],
+    "create cylinder by size": additive["cylinder_by_size"],
+    "cylinder by radius and height": additive["cylinder_by_size"],
+
+    # Revolution by dictated angle
+    "revolution by angle": additive["revolve_by_angle"],
+    "revolve by angle": additive["revolve_by_angle"],
+    "spin profile": additive["revolve_by_angle"],
 
     "help":            additive['help'],
     "info":            additive['help'],

--- a/Dav/dic/Workbench/PartDesign/additive/TraduceToEs.py
+++ b/Dav/dic/Workbench/PartDesign/additive/TraduceToEs.py
@@ -16,8 +16,8 @@
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import additive as additive
-import ayuda as ayuda
+from .additive import additive
+from .ayuda import ayuda
 
 TraduceToEs = {
     # Rellenar
@@ -131,6 +131,29 @@ TraduceToEs = {
     "mezclar formas": additive["loft_profiles"],
     "barrer superficies": additive["loft_profiles"],
     "deformar secciones": additive["loft_profiles"],
+
+
+    # Extrusion por medida dictada (sin dialogo)
+    "extruir por medida": additive["pad_by_length"],
+    "extruir por altura": additive["pad_by_length"],
+    "extruir altura": additive["pad_by_length"],
+    "dar altura": additive["pad_by_length"],
+
+    # Caja por dimensiones dictadas
+    "caja por medidas": additive["box_by_size"],
+    "cubo por medidas": additive["box_by_size"],
+    "crear caja por medidas": additive["box_by_size"],
+    "caja por dimensiones": additive["box_by_size"],
+
+    # Cilindro por dimensiones dictadas
+    "cilindro por medidas": additive["cylinder_by_size"],
+    "crear cilindro por medidas": additive["cylinder_by_size"],
+    "cilindro por radio y altura": additive["cylinder_by_size"],
+
+    # Revolucion por angulo dictado
+    "revolucion por angulo": additive["revolve_by_angle"],
+    "revolver por angulo": additive["revolve_by_angle"],
+    "girar perfil": additive["revolve_by_angle"],
 
     #Ayuda
     "ayuda":                additive["help"],

--- a/Dav/dic/Workbench/PartDesign/additive/TraduceToPt.py
+++ b/Dav/dic/Workbench/PartDesign/additive/TraduceToPt.py
@@ -16,8 +16,8 @@
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import additive as additive
-import ayuda as ayuda
+from .additive import additive
+from .ayuda import ayuda
 
 TraduceToPt = {
     #Ressalto
@@ -85,6 +85,27 @@ TraduceToPt = {
     "mesclar formas": additive["loft_profiles"],
     "varrer superfícies": additive["loft_profiles"],
     "deformar seções": additive["loft_profiles"],
+
+
+    # Extrusao por medida ditada (sem dialogo)
+    "extrudar por medida": additive["pad_by_length"],
+    "extrudar por altura": additive["pad_by_length"],
+    "dar altura": additive["pad_by_length"],
+
+    # Caixa por dimensoes ditadas
+    "caixa por medidas": additive["box_by_size"],
+    "cubo por medidas": additive["box_by_size"],
+    "criar caixa por medidas": additive["box_by_size"],
+    "caixa por dimensoes": additive["box_by_size"],
+
+    # Cilindro por dimensoes ditadas
+    "cilindro por medidas": additive["cylinder_by_size"],
+    "criar cilindro por medidas": additive["cylinder_by_size"],
+    "cilindro por raio e altura": additive["cylinder_by_size"],
+
+    # Revolucao por angulo ditado
+    "revolucao por angulo": additive["revolve_by_angle"],
+    "girar perfil": additive["revolve_by_angle"],
 
     "ajuda":             additive["help"],
     "informação":       additive["help"],

--- a/Dav/dic/Workbench/PartDesign/additive/_parametric.py
+++ b/Dav/dic/Workbench/PartDesign/additive/_parametric.py
@@ -1,19 +1,263 @@
 # Copyright (C) 2026 El Equipo del Proyecto DAV
+# Universidad Autónoma de Entre Ríos (UADER)
+# Bajo la dirección de Guillermo Gerard y Gallo Fabricio David
+#
+# Este programa es software libre: usted puede redistribuirlo y/o modificarlo
+# bajo los términos de la Licencia Pública General GNU tal como fue publicada
+# por la Fundación para el Software Libre, en la versión 3 de la Licencia.
+#
+# Este programa se distribuye con la esperanza de que sea útil,
+# pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+# MERCANTIBILIDAD o APTITUD PARA UN PROPÓSITO PARTICULAR. Consulte la
+# Licencia Pública General GNU para más detalles.
+#
+# Deberías haber recibido una copia de la Licencia Pública General GNU
+# junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Parametric additive commands for Validator (object parameters)."""
+"""Parametric additive commands for Validator (numbers and objects)."""
 
 from __future__ import annotations
 
+import FreeCAD as App
 import FreeCADGui as Gui
 
 
+def _RegisterObject(Feature) -> None:
+    """Register a created feature in the DAV navigable object tree."""
+    try:
+        from createobjects import CreateObjects
+    except ImportError:
+        from selection.createobjects import CreateObjects
+    CreateObjects(ObjectName=Feature.Name, Is3D=True).Execute()
+
+
+def _SketchFromShape(Doc, Source, Name: str):
+    """Copy a flat Part shape's edges into a new Sketcher object.
+
+    PartDesign features need a ``Sketcher::SketchObject`` profile, but the DAV
+    geometry commands produce loose ``Part::Feature`` objects. This rebuilds
+    the outline as a sketch so shapes dictated by voice can be padded directly.
+
+    Args:
+        Doc: Active FreeCAD document.
+        Source: Object whose ``Shape`` edges are copied.
+        Name: Internal name for the new sketch.
+
+    Returns:
+        The created sketch, or None when Source carries no usable geometry.
+    """
+    shape = getattr(Source, "Shape", None)
+    if shape is None or not shape.Edges:
+        return None
+
+    sketch = Doc.addObject("Sketcher::SketchObject", Name)
+    for edge in shape.Edges:
+        try:
+            sketch.addGeometry(edge.Curve, False)
+        except Exception as error:
+            # una arista no convertible no invalida el resto del perfil
+            print(f"[additive] Skipped an edge while building the sketch: {error}")
+    return sketch
+
+
+def _ResolveProfile(Doc, Target):
+    """Return a padable profile for Target, converting a Part shape if needed."""
+    if Target is None:
+        return None
+    if Target.isDerivedFrom("Sketcher::SketchObject"):
+        return Target
+    return _SketchFromShape(Doc, Target, f"{Target.Name}Profile")
+
+
+def _SelectedOrActive(Doc):
+    """Return the current selection, falling back to the active object."""
+    try:
+        selection = Gui.Selection.getSelection()
+    except Exception:
+        selection = []
+    if selection:
+        return selection[0]
+    return getattr(Doc, "ActiveObject", None)
+
+
+def pad_by_length(length: float) -> None:
+    """Extrude the selected 2D profile by a dictated length.
+
+    This is the voice path from a flat shape to a solid: draw a square with the
+    Sketcher geometry commands, select it, and say the height. Unlike ``pad``,
+    no FreeCAD dialog is opened -- the length comes from the prompt, so the
+    whole flow runs without mouse or keyboard.
+
+    A loose ``Part::Feature`` (what the DAV geometry commands create) is
+    converted to a sketch first, since PartDesign only pads sketches.
+
+    Args:
+        length: Extrusion height, in millimetres. Must be greater than zero.
+
+    Example::
+
+        pad_by_length(30)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[additive] Error: no active document.")
+        return
+    if length <= 0:
+        print(f"[additive] Error: length must be greater than zero (got {length}).")
+        return
+
+    target = _SelectedOrActive(doc)
+    if target is None:
+        print("[additive] Error: select a 2D profile to extrude first.")
+        return
+
+    profile = _ResolveProfile(doc, target)
+    if profile is None:
+        print(f"[additive] Error: '{getattr(target, 'Name', target)}' has no usable outline.")
+        return
+
+    body = doc.addObject("PartDesign::Body", "Body")
+    body.addObject(profile)
+
+    pad = doc.addObject("PartDesign::Pad", "Pad")
+    pad.Profile = profile
+    pad.Length = length
+    body.addObject(pad)
+
+    # el perfil plano ya no aporta nada visual una vez que hay solido
+    if target is not profile:
+        target.Visibility = False
+
+    doc.recompute()
+    _RegisterObject(pad)
+    print(f"[additive] Padded '{profile.Name}' by {length}")
+
+
+def box_by_size(length: float, width: float, height: float) -> None:
+    """Create a box from three dictated dimensions.
+
+    Skips the sketch entirely: useful when the goal is a plain cube and there
+    is no profile to extrude. Say three equal values to get a cube.
+
+    Args:
+        length: Size along X, in millimetres.
+        width: Size along Y, in millimetres.
+        height: Size along Z, in millimetres.
+
+    Example::
+
+        box_by_size(20, 20, 20)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[additive] Error: no active document.")
+        return
+    if length <= 0 or width <= 0 or height <= 0:
+        print("[additive] Error: every dimension must be greater than zero.")
+        return
+
+    body = doc.addObject("PartDesign::Body", "Body")
+    box = doc.addObject("PartDesign::AdditiveBox", "Box")
+    box.Length = length
+    box.Width = width
+    box.Height = height
+    body.addObject(box)
+
+    doc.recompute()
+    _RegisterObject(box)
+    print(f"[additive] Created box {length} x {width} x {height}")
+
+
+def cylinder_by_size(radius: float, height: float) -> None:
+    """Create a cylinder from a dictated radius and height.
+
+    Args:
+        radius: Base radius, in millimetres.
+        height: Cylinder height, in millimetres.
+
+    Example::
+
+        cylinder_by_size(10, 40)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[additive] Error: no active document.")
+        return
+    if radius <= 0 or height <= 0:
+        print("[additive] Error: radius and height must be greater than zero.")
+        return
+
+    body = doc.addObject("PartDesign::Body", "Body")
+    cylinder = doc.addObject("PartDesign::AdditiveCylinder", "Cylinder")
+    cylinder.Radius = radius
+    cylinder.Height = height
+    body.addObject(cylinder)
+
+    doc.recompute()
+    _RegisterObject(cylinder)
+    print(f"[additive] Created cylinder radius {radius} height {height}")
+
+
+def revolve_by_angle(angle: float) -> None:
+    """Revolve the selected 2D profile by a dictated angle.
+
+    Args:
+        angle: Sweep angle, in degrees. Must be between 0 and 360.
+
+    Example::
+
+        revolve_by_angle(180)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[additive] Error: no active document.")
+        return
+    if angle <= 0 or angle > 360:
+        print(f"[additive] Error: angle must be between 0 and 360 (got {angle}).")
+        return
+
+    target = _SelectedOrActive(doc)
+    if target is None:
+        print("[additive] Error: select a 2D profile to revolve first.")
+        return
+
+    profile = _ResolveProfile(doc, target)
+    if profile is None:
+        print(f"[additive] Error: '{getattr(target, 'Name', target)}' has no usable outline.")
+        return
+
+    body = doc.addObject("PartDesign::Body", "Body")
+    body.addObject(profile)
+
+    revolution = doc.addObject("PartDesign::Revolution", "Revolution")
+    revolution.Profile = profile
+    revolution.Angle = angle
+    body.addObject(revolution)
+
+    if target is not profile:
+        target.Visibility = False
+
+    doc.recompute()
+    _RegisterObject(revolution)
+    print(f"[additive] Revolved '{profile.Name}' by {angle} degrees")
+
+
 def pad_sketch(sketch: object, length: float = 10.0) -> None:
-    """Select a sketch and launch PartDesign Pad."""
+    """Select a sketch and launch PartDesign Pad.
+
+    Kept for the interactive path: this opens FreeCAD's own Pad dialog, so the
+    height is typed rather than dictated. Use ``pad_by_length`` to stay on
+    voice.
+
+    Args:
+        sketch: Sketch object to pad.
+        length: Unused; the dialog owns the length. See ``pad_by_length``.
+    """
     Gui.Selection.clearSelection()
     Gui.Selection.addSelection(sketch)
     Gui.runCommand("PartDesign_Pad", 0)
-    print(f"[additive] Pad on '{getattr(sketch, 'Name', sketch)}' length={length}")
+    print(f"[additive] Pad dialog opened on '{getattr(sketch, 'Name', sketch)}'")
 
 
 def loft_profiles(profile_a: object, profile_b: object) -> None:

--- a/Dav/dic/Workbench/PartDesign/additive/additive.py
+++ b/Dav/dic/Workbench/PartDesign/additive/additive.py
@@ -17,7 +17,14 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 from .ayuda import ayuda
-from ._parametric import loft_profiles, pad_sketch
+from ._parametric import (
+    box_by_size,
+    cylinder_by_size,
+    loft_profiles,
+    pad_by_length,
+    pad_sketch,
+    revolve_by_angle,
+)
 
 
 def _create_additive_primitive(type_id: str, default_name: str, is_3d: bool = True) -> None:
@@ -110,6 +117,10 @@ additive = {
     'additivetorus':     additive_torus,
     'additivewedge':     additive_wedge,
     'pad_sketch':        pad_sketch,
+    'pad_by_length':     pad_by_length,
+    'box_by_size':       box_by_size,
+    'cylinder_by_size':  cylinder_by_size,
+    'revolve_by_angle':  revolve_by_angle,
     'loft_profiles':     loft_profiles,
     'help':              ayuda,
 }

--- a/Dav/dic/Workbench/PartDesign/base/TraduceToEn.py
+++ b/Dav/dic/Workbench/PartDesign/base/TraduceToEn.py
@@ -16,8 +16,8 @@
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import base as base
-import ayuda as ayuda
+from .base import base
+from .ayuda import ayuda
 
 TraduceToEn = {
     # Body

--- a/Dav/dic/Workbench/PartDesign/base/TraduceToEs.py
+++ b/Dav/dic/Workbench/PartDesign/base/TraduceToEs.py
@@ -16,8 +16,8 @@
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import base as base
-import ayuda as ayuda
+from .base import base
+from .ayuda import ayuda
 
 TraduceToEs = {
     #Body
@@ -27,12 +27,12 @@ TraduceToEs = {
     "nuevo cuerpo": base["body"],
     
     #Nuevo croquis
-    "nuevo croquis": base["new sketch"],
-    "crear croquis": base["new sketch"],
-    "croquis nuevo": base["new sketch"],
-    "nuevo boceto": base["new sketch"],
-    "crear boceto": base["new sketch"],
-    "boceto nuevo": base["new sketch"],
+    "nuevo croquis": base["newsketch"],
+    "crear croquis": base["newsketch"],
+    "croquis nuevo": base["newsketch"],
+    "nuevo boceto": base["newsketch"],
+    "crear boceto": base["newsketch"],
+    "boceto nuevo": base["newsketch"],
 
     #Clonar
     "clonar":        base["clone"],

--- a/Dav/dic/Workbench/PartDesign/base/TraduceToPt.py
+++ b/Dav/dic/Workbench/PartDesign/base/TraduceToPt.py
@@ -16,8 +16,8 @@
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import base as base
-import ayuda as ayuda
+from .base import base
+from .ayuda import ayuda
 
 TraduceToPt = {
     #Corpo

--- a/Dav/dic/Workbench/PartDesign/manage/TraduceToEn.py
+++ b/Dav/dic/Workbench/PartDesign/manage/TraduceToEn.py
@@ -16,8 +16,8 @@
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import manage as manage
-import ayuda as ayuda
+from .manage import manage
+from .ayuda import ayuda
 
 TraduceToEn = {
     # MoveFeature

--- a/Dav/dic/Workbench/PartDesign/manage/TraduceToEs.py
+++ b/Dav/dic/Workbench/PartDesign/manage/TraduceToEs.py
@@ -16,8 +16,8 @@
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import manage as manage
-import ayuda as ayuda
+from .manage import manage
+from .ayuda import ayuda
 
 TraduceToEs = {
     # Mover elemento

--- a/Dav/dic/Workbench/PartDesign/manage/TraduceToPt.py
+++ b/Dav/dic/Workbench/PartDesign/manage/TraduceToPt.py
@@ -16,8 +16,8 @@
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import manage as manage
-import ayuda as ayuda
+from .manage import manage
+from .ayuda import ayuda
 
 TraduceToPt= {
     #Mover recurso


### PR DESCRIPTION
Continúa el #208 (ya integrado). Este PR cierra el flujo **2D → 3D sin mouse ni teclado**.

## El problema

`pad` abría el diálogo de FreeCAD para escribir la altura, y `part_extrude` extruía siempre **10 mm hardcodeados**:

```python
f.Dir = Vector(0, 0, 10)   # siempre 10
```

Es decir: la medida nunca se podía dictar. Se podía invocar la extrusión por voz, pero había que completarla con el teclado.

## Comandos nuevos

| Comando | Parámetros dictados | Resultado |
|---|---|---|
| `pad_by_length` | length | perfil 2D → sólido |
| `box_by_size` | length, width, height | caja / cubo directo |
| `cylinder_by_size` | radius, height | cilindro directo |
| `revolve_by_angle` | angle | perfil → revolución |

Usan la **API directa** (`PartDesign::Pad` con `.Profile` y `.Length`, siguiendo el patrón de los tests de FreeCAD en `TestLinearPattern.py`) en vez de `Gui.runCommand`. Eso es lo que permite fijar la medida sin abrir diálogo.

## Perfiles: Part::Feature → croquis

PartDesign solo extruye `Sketcher::SketchObject`, pero los comandos de geometría de DAV producen `Part::Feature` sueltos. `_SketchFromShape` reconstruye el contorno como croquis, así que **un cuadrado dictado con `rectangulo por esquinas` ya es padeable**.

`pad_sketch` recibía un parámetro `length` que imprimía y descartaba — el diálogo se quedaba con la altura. Queda documentado como camino interactivo, con `pad_by_length` como el camino por voz.

## Tres bugs preexistentes que dejaban PartDesign mudo

Aparecieron al verificar el ruteo, no los buscaba:

1. **`additive`, `base` y `manage` hacían `import additive as additive`** — import absoluto que falla, porque el loader los importa como `Workbench.PartDesign.<carpeta>.TraduceTo*`. El loader aísla el módulo roto y sigue con mapa vacío, así que **ninguna frase de esas tres carpetas era alcanzable por voz**, en silencio y sin error visible.
2. **`additive/TraduceToEn.py` definía `traduceToEn`** en minúscula; el loader busca `getattr(module, "TraduceToEn")`.
3. **`base/TraduceTo*` indexaba `base["new sketch"]`** cuando la clave real es `newsketch` → `KeyError` que reventaba el módulo entero.

Los **18 diccionarios de PartDesign** cargan ahora en los tres idiomas (antes 3 carpetas × 3 idiomas estaban caídas).

## Cómo probar

```
workbench → partdesign → aditivo

caja por medidas        → veinte / veinte / veinte   → cubo
cilindro por medidas    → diez / cuarenta
extruir por medida      → treinta                    (con un perfil seleccionado)
revolucion por angulo   → noventa
```

Flujo completo por voz:

```
sketcher → geometria → rectangulo por esquinas → 0 / 0 / 20 / 20
partdesign → aditivo → extruir por medida → veinte
= cubo, sin tocar mouse ni teclado
```

> El diccionario numérico llega hasta **99**, así que para revolución usar `noventa` y no `ciento ochenta`. Extender el rango queda como pendiente aparte.

## Verificación

Con stubs de FreeCAD: firmas (= cantidad de prompts), ruteo de las 12 frases nuevas en es/en/pt, que los valores dictados llegan efectivamente a `Pad.Length` / `Box.Length` / `Cylinder.Radius` / `Revolution.Angle`, la conversión `Part::Feature` → croquis (4 aristas, perfil plano ocultado) y las 4 guardas de error. Se revalidó después de mergear `upstream/DavCore`.

**No se ejecutó dentro de FreeCAD real.** La conversión a croquis es lo que más conviene probar en la app: `addGeometry` con curvas reales puede comportarse distinto que con el stub.