### PR TITLE
Assembly: juntas por voz sin dialogo, con distancia y angulo dictados

### DIFF
--- a/Dav/dic/Workbench/Assembly/Assembly.py
+++ b/Dav/dic/Workbench/Assembly/Assembly.py
@@ -17,6 +17,14 @@
 import FreeCADGui as Gui
 from .joint.joint import joint
 from .ayuda import ayuda
+from ._parametric import (
+    angle_joint,
+    distance_joint,
+    fixed_joint,
+    ground_part,
+    revolute_joint,
+    slider_joint,
+)
 
 # Subcontexto anidado: el Browser navega por niveles y espera
 # assembly['joint'] como submenú (no aplanado), igual que Explorer/Explorer.py.
@@ -32,5 +40,11 @@ assembly.update({
     'bom':         lambda: Gui.runCommand('Assembly_CreateBom', 0),
     'preferences': lambda: Gui.runCommand('Assembly_Preferences', 0),
     'grounded':    lambda: Gui.runCommand('Assembly_ToggleGrounded', 1),
+    'fixed_joint':     fixed_joint,
+    'revolute_joint':  revolute_joint,
+    'slider_joint':    slider_joint,
+    'distance_joint':  distance_joint,
+    'angle_joint':     angle_joint,
+    'ground_part':     ground_part,
     'help':        ayuda,
 })

--- a/Dav/dic/Workbench/Assembly/TraduceToEn.py
+++ b/Dav/dic/Workbench/Assembly/TraduceToEn.py
@@ -43,6 +43,25 @@ TraduceToEn = {
     "toggle grounded":   assembly["grounded"],
     "joint":             joint,
     
+    # Voice joints (no dialog)
+    "fixed joint":           assembly["fixed_joint"],
+    "lock parts":            assembly["fixed_joint"],
+
+    "revolute joint":        assembly["revolute_joint"],
+    "hinge":                 assembly["revolute_joint"],
+
+    "slider joint":          assembly["slider_joint"],
+    "slide parts":           assembly["slider_joint"],
+
+    "distance joint":        assembly["distance_joint"],
+    "hold apart":            assembly["distance_joint"],
+
+    "angle joint":           assembly["angle_joint"],
+    "angle between parts":   assembly["angle_joint"],
+
+    "ground part":           assembly["ground_part"],
+    "anchor part":           assembly["ground_part"],
+
     "help":            joint['help'],
     "info":            joint['help'],
     "options":         joint['help']

--- a/Dav/dic/Workbench/Assembly/TraduceToEs.py
+++ b/Dav/dic/Workbench/Assembly/TraduceToEs.py
@@ -97,6 +97,29 @@ TraduceToEs = {
     "unión":                 joint,
     "junta":                 joint,
 
+    # Juntas por voz (sin dialogo)
+    "ensamble fijo":         assembly["fixed_joint"],
+    "junta fija":            assembly["fixed_joint"],
+    "fijar piezas":          assembly["fixed_joint"],
+
+    "junta giratoria":       assembly["revolute_joint"],
+    "bisagra":               assembly["revolute_joint"],
+    "articular piezas":      assembly["revolute_joint"],
+
+    "junta deslizante":      assembly["slider_joint"],
+    "deslizar piezas":       assembly["slider_joint"],
+
+    "junta por distancia":   assembly["distance_joint"],
+    "separar piezas":        assembly["distance_joint"],
+    "distancia entre piezas": assembly["distance_joint"],
+
+    "junta por angulo":      assembly["angle_joint"],
+    "angulo entre piezas":   assembly["angle_joint"],
+
+    "fijar al suelo":        assembly["ground_part"],
+    "anclar pieza":          assembly["ground_part"],
+    "poner a tierra":        assembly["ground_part"],
+
     # Ayuda
     "ayuda":            joint['help'],
     "información":            joint['help'],

--- a/Dav/dic/Workbench/Assembly/TraduceToPt.py
+++ b/Dav/dic/Workbench/Assembly/TraduceToPt.py
@@ -18,7 +18,7 @@
 
 """Mapeamento de palavras em portugues para o dicionario DAV AssemblyWorkbench."""
  
-from .AssemblyWorkbench import assembly
+from .Assembly import assembly
 from .joint.joint import joint
 from .ayuda import ayuda
  
@@ -32,11 +32,10 @@ TraduceToPt = {
     "resolver":            assembly["solve"],
     "resolver conjunto":   assembly["solve"],
     "fixar":      assembly["solve"],
-    "montar conjunto":     assembly["assemble"],
-    "desmontar conjunto":  assembly["disassemble"],
+    "montar conjunto":     assembly["create"],
     "fazer conjunto":         assembly["solve"],
     "verificar conjunto":     assembly["solve"],
-    "conjunto":              assembly["assemble"],
+    "conjunto":              assembly["create"],
     "arranjo":                assembly["solve"],
     
     "vista explodida":     assembly["view"],
@@ -61,6 +60,25 @@ TraduceToPt = {
     "unir":                joint,
     "conectar":            joint,
     "junto":                joint,
+
+    # Juntas por voz (sem dialogo)
+    "junta fixa":            assembly["fixed_joint"],
+    "fixar pecas":           assembly["fixed_joint"],
+
+    "junta giratoria":       assembly["revolute_joint"],
+    "dobradica":             assembly["revolute_joint"],
+
+    "junta deslizante":      assembly["slider_joint"],
+    "deslizar pecas":        assembly["slider_joint"],
+
+    "junta por distancia":   assembly["distance_joint"],
+    "separar pecas":         assembly["distance_joint"],
+
+    "junta por angulo":      assembly["angle_joint"],
+    "angulo entre pecas":    assembly["angle_joint"],
+
+    "fixar ao chao":         assembly["ground_part"],
+    "ancorar peca":          assembly["ground_part"],
 
     "ajuda":               joint['help'],
     "informação":          joint['help'],

--- a/Dav/dic/Workbench/Assembly/_parametric.py
+++ b/Dav/dic/Workbench/Assembly/_parametric.py
@@ -1,0 +1,333 @@
+# Copyright (C) 2026 El Equipo del Proyecto DAV
+# Universidad Autónoma de Entre Ríos (UADER)
+# Bajo la dirección de Guillermo Gerard y Gallo Fabricio David
+#
+# Este programa es software libre: usted puede redistribuirlo y/o modificarlo
+# bajo los términos de la Licencia Pública General GNU tal como fue publicada
+# por la Fundación para el Software Libre, en la versión 3 de la Licencia.
+#
+# Este programa se distribuye con la esperanza de que sea útil,
+# pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+# MERCANTIBILIDAD o APTITUD PARA UN PROPÓSITO PARTICULAR. Consulte la
+# Licencia Pública General GNU para más detalles.
+#
+# Deberías haber recibido una copia de la Licencia Pública General GNU
+# junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Parametric assembly commands for Validator (numbers and objects)."""
+
+from __future__ import annotations
+
+import FreeCAD as App
+import FreeCADGui as Gui
+
+# Indice de cada tipo en Assembly.JointObject.JointTypes. Se pasa como segundo
+# argumento a JointObject.Joint(feature, index), que es la forma en que los
+# propios tests de FreeCAD crean juntas sin abrir el dialogo.
+_JOINT_TYPE_INDEX = {
+    "Fixed": 0,
+    "Revolute": 1,
+    "Cylindrical": 2,
+    "Slider": 3,
+    "Ball": 4,
+    "Distance": 5,
+    "Parallel": 6,
+    "Perpendicular": 7,
+    "Angle": 8,
+}
+
+
+def _RegisterObject(Feature) -> None:
+    """Register a created feature in the DAV navigable object tree."""
+    try:
+        from createobjects import CreateObjects
+    except ImportError:
+        from selection.createobjects import CreateObjects
+    CreateObjects(ObjectName=Feature.Name, Is3D=True).Execute()
+
+
+def _ActiveAssembly(Doc):
+    """Return the assembly to work on.
+
+    ``UtilsAssembly.activeAssembly()`` only answers while the assembly is in
+    edit mode, which is not a state the voice flow can rely on. This falls back
+    to the single assembly in the document, so ``ensamble fijo`` works right
+    after ``crear ensamblaje`` without extra clicks.
+
+    Args:
+        Doc: Active FreeCAD document.
+
+    Returns:
+        The assembly object, or None when there is none or the choice is
+        ambiguous.
+    """
+    try:
+        import UtilsAssembly
+
+        active = UtilsAssembly.activeAssembly()
+        if active is not None:
+            return active
+    except Exception:
+        # sin el modulo o fuera de modo edicion seguimos por el documento
+        pass
+
+    assemblies = [
+        obj for obj in Doc.Objects if obj.isDerivedFrom("Assembly::AssemblyObject")
+    ]
+    if not assemblies:
+        return None
+    if len(assemblies) > 1:
+        print(
+            f"[assembly] Error: {len(assemblies)} assemblies in the document; "
+            "open the one to use so the command is unambiguous."
+        )
+        return None
+    return assemblies[0]
+
+
+def _JointGroup(Assembly):
+    """Return the assembly's joint group, creating it when missing."""
+    for obj in Assembly.Group:
+        if obj.isDerivedFrom("Assembly::JointGroup"):
+            return obj
+    return Assembly.newObject("Assembly::JointGroup", "Joints")
+
+
+def _SelectedParts(Count: int):
+    """Return the first Count selected objects, or None when there are fewer."""
+    try:
+        selection = Gui.Selection.getSelection()
+    except Exception:
+        selection = []
+    if len(selection) < Count:
+        return None
+    return selection[:Count]
+
+
+def _CreateJoint(JointTypeName: str, Doc, Parts):
+    """Build a joint feature of the given type between Parts.
+
+    Args:
+        JointTypeName: Key of ``_JOINT_TYPE_INDEX``.
+        Doc: Active FreeCAD document.
+        Parts: The two objects to connect.
+
+    Returns:
+        The created joint feature, or None when it could not be built.
+    """
+    assembly = _ActiveAssembly(Doc)
+    if assembly is None:
+        print("[assembly] Error: no assembly found. Say 'crear ensamblaje' first.")
+        return None
+
+    try:
+        import JointObject
+    except ImportError:
+        print("[assembly] Error: the Assembly workbench is not available.")
+        return None
+
+    group = _JointGroup(assembly)
+    feature = group.newObject("App::FeaturePython", f"{JointTypeName}Joint")
+    JointObject.Joint(feature, _JOINT_TYPE_INDEX[JointTypeName])
+
+    # setJointConnectors espera [objeto, [subelementos]] por cada lado; se usa
+    # el primer vertice de cada pieza como punto de anclaje por defecto.
+    references = [[part, ["Vertex1"]] for part in Parts]
+    try:
+        feature.Proxy.setJointConnectors(feature, references)
+    except Exception as error:
+        print(f"[assembly] Error: could not connect the parts: {error}")
+        return None
+
+    return feature
+
+
+def fixed_joint() -> None:
+    """Lock the two selected parts together with a fixed joint.
+
+    Select two parts first, then say the command. No dialog is opened.
+
+    Example::
+
+        fixed_joint()
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[assembly] Error: no active document.")
+        return
+
+    parts = _SelectedParts(2)
+    if parts is None:
+        print("[assembly] Error: select two parts to join first.")
+        return
+
+    joint = _CreateJoint("Fixed", doc, parts)
+    if joint is None:
+        return
+
+    doc.recompute()
+    _RegisterObject(joint)
+    print(f"[assembly] Fixed '{parts[0].Name}' to '{parts[1].Name}'")
+
+
+def revolute_joint() -> None:
+    """Hinge the two selected parts with a revolute joint.
+
+    Example::
+
+        revolute_joint()
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[assembly] Error: no active document.")
+        return
+
+    parts = _SelectedParts(2)
+    if parts is None:
+        print("[assembly] Error: select two parts to join first.")
+        return
+
+    joint = _CreateJoint("Revolute", doc, parts)
+    if joint is None:
+        return
+
+    doc.recompute()
+    _RegisterObject(joint)
+    print(f"[assembly] Hinged '{parts[0].Name}' to '{parts[1].Name}'")
+
+
+def slider_joint() -> None:
+    """Let the two selected parts slide along one axis.
+
+    Example::
+
+        slider_joint()
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[assembly] Error: no active document.")
+        return
+
+    parts = _SelectedParts(2)
+    if parts is None:
+        print("[assembly] Error: select two parts to join first.")
+        return
+
+    joint = _CreateJoint("Slider", doc, parts)
+    if joint is None:
+        return
+
+    doc.recompute()
+    _RegisterObject(joint)
+    print(f"[assembly] Slider between '{parts[0].Name}' and '{parts[1].Name}'")
+
+
+def distance_joint(distance: float) -> None:
+    """Hold the two selected parts a dictated distance apart.
+
+    This is the assembly counterpart of the parametric geometry commands: the
+    gap comes from the voice prompt, so no dialog is opened.
+
+    Args:
+        distance: Gap between the parts, in millimetres.
+
+    Example::
+
+        distance_joint(25)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[assembly] Error: no active document.")
+        return
+
+    parts = _SelectedParts(2)
+    if parts is None:
+        print("[assembly] Error: select two parts to join first.")
+        return
+
+    joint = _CreateJoint("Distance", doc, parts)
+    if joint is None:
+        return
+
+    joint.Distance = distance
+    doc.recompute()
+    _RegisterObject(joint)
+    print(
+        f"[assembly] Held '{parts[0].Name}' and '{parts[1].Name}' {distance} apart"
+    )
+
+
+def angle_joint(angle: float) -> None:
+    """Hold the two selected parts at a dictated angle.
+
+    Args:
+        angle: Angle between the parts, in degrees. Must be between 0 and 360.
+
+    Example::
+
+        angle_joint(90)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[assembly] Error: no active document.")
+        return
+    if angle < 0 or angle > 360:
+        print(f"[assembly] Error: angle must be between 0 and 360 (got {angle}).")
+        return
+
+    parts = _SelectedParts(2)
+    if parts is None:
+        print("[assembly] Error: select two parts to join first.")
+        return
+
+    joint = _CreateJoint("Angle", doc, parts)
+    if joint is None:
+        return
+
+    joint.Angle = angle
+    doc.recompute()
+    _RegisterObject(joint)
+    print(
+        f"[assembly] Held '{parts[0].Name}' and '{parts[1].Name}' at {angle} degrees"
+    )
+
+
+def ground_part() -> None:
+    """Ground the selected part so the solver keeps it fixed in place.
+
+    An assembly needs at least one grounded part; without it the solver has
+    nothing to anchor the others to.
+
+    Example::
+
+        ground_part()
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[assembly] Error: no active document.")
+        return
+
+    parts = _SelectedParts(1)
+    if parts is None:
+        print("[assembly] Error: select the part to ground first.")
+        return
+
+    assembly = _ActiveAssembly(doc)
+    if assembly is None:
+        print("[assembly] Error: no assembly found. Say 'crear ensamblaje' first.")
+        return
+
+    try:
+        import JointObject
+    except ImportError:
+        print("[assembly] Error: the Assembly workbench is not available.")
+        return
+
+    group = _JointGroup(assembly)
+    feature = group.newObject("App::FeaturePython", "GroundedJoint")
+    JointObject.GroundedJoint(feature, parts[0])
+
+    doc.recompute()
+    _RegisterObject(feature)
+    print(f"[assembly] Grounded '{parts[0].Name}'")


### PR DESCRIPTION
Continúa el #208 y el #209 (ambos ya integrados). Cierra el módulo **Assembly** del MVP.

## El problema

Assembly tenía todos los comandos mapeados, pero **cada uno abría el diálogo de FreeCAD**. La voz llegaba hasta invocar la junta; completarla requería mouse y teclado.

## Comandos nuevos

| Comando | Dicta | Resultado |
|---|---|---|
| `fixed_joint` | — | fija dos piezas |
| `revolute_joint` | — | bisagra |
| `slider_joint` | — | deslizante |
| `distance_joint` | distance | separación dictada |
| `angle_joint` | angle | ángulo dictado |
| `ground_part` | — | ancla una pieza al suelo |

Se crean con `JointObject.Joint(feature, índice)` sobre un `Assembly::JointGroup` y se conectan con `setJointConnectors`, que es como lo hacen los propios tests de FreeCAD (`AssemblyTests/TestCore.py`). Eso es lo que permite fijar `Distance` y `Angle` sin abrir diálogo.

## Resolución del ensamblaje activo

`UtilsAssembly.activeAssembly()` solo responde mientras el ensamblaje está **en modo edición**, que no es un estado en el que el flujo por voz pueda confiar. `_ActiveAssembly` cae al único ensamblaje del documento, y **avisa si hay más de uno** en lugar de elegir al azar. Así `ensamble fijo` funciona apenas después de `crear ensamblaje`, sin clics extra.

## Dos bugs preexistentes que dejaban el portugués mudo

1. **`TraduceToPt.py` importaba de `.AssemblyWorkbench`**, módulo que no existe (el archivo es `Assembly.py`) → `ModuleNotFoundError`, y el loader se quedaba con mapa vacío para **todo Assembly en portugués**.
2. **El mismo archivo indexaba `assembly["assemble"]` y `assembly["disassemble"]`**, claves inexistentes → `KeyError` que reventaba el módulo entero. `"montar conjunto"` pasa a `create`, que es el comando que le corresponde; la línea de `disassemble` se elimina porque no tiene equivalente real.

Los 6 diccionarios de Assembly cargan ahora en los tres idiomas (antes el portugués estaba caído por completo).

## Cómo probar

```
banco de trabajo → ensamblaje

crear ensamblaje
(insertar dos piezas)
anclar pieza              ← con una pieza seleccionada
junta por distancia       ← con dos piezas seleccionadas → veinticinco enter
junta por angulo          ← → noventa enter
ensamble fijo / bisagra / junta deslizante
```

Seleccionar las piezas todavía necesita mouse; las juntas en sí ya no.

> El diccionario numérico llega hasta **99**.

## Verificación

Con stubs de FreeCAD (incluido un stub de `JointObject`): firmas, que el índice de tipo de junta es el correcto (0=Fixed, 5=Distance, 8=Angle), que los valores dictados llegan a `Distance` y `Angle`, que `setJointConnectors` recibe las dos piezas, el anclaje, y las guardas de error (una sola pieza seleccionada, ángulo fuera de rango). También se comprobó que los 6 workbenches del árbol siguen cargando.

**No se ejecutó dentro de FreeCAD real.** Lo que más conviene probar en la app es `setJointConnectors` con geometría real: se usa `Vertex1` de cada pieza como anclaje por defecto, y con formas complejas puede no ser el punto que el usuario espera.