### PR TITLE
docs: agregar informe de pruebas y validacion de DraftWork

### DIFF
--- a/Dav/docs/informe_pruebas_draftwork.md
+++ b/Dav/docs/informe_pruebas_draftwork.md
@@ -1,0 +1,47 @@
+# Informe de Validación y Pruebas — Banco de Trabajo Draft (`DraftWork`)
+
+**Proyecto:** DAV (Diseño Asistido por Voz / Selección Accesible para FreeCAD)  
+**Fecha:** 31 de Agosto de 2026  
+**Rama base:** `DavCore`  
+**Módulo evaluado:** `Dav/dic/Workbench/DraftWork`  
+
+---
+
+## 1. Objetivo
+Verificar la integración, la navegación por voz y la correcta ejecución de todas las herramientas y geometrías correspondientes al banco de trabajo **Draft (`DraftWork`)** en FreeCAD a través del sistema de subcontextos de DAV.
+
+---
+
+## 2. Metodología de Prueba
+1. **Arranque:** Ejecución del entorno mediante `iniciar_dav.bat`.
+2. **Activación de Entorno:** Carga del banco `DraftWorkbench` y creación de un documento nuevo en FreeCAD.
+3. **Navegación de Voz:**
+   * Entrada: `Base` → `mesa de trabajo` (`workbench`) → `banco de dibujo` (`draft`).
+   * Descenso y ejecución en cada submódulo (`circulo`, `arco`, `elipse`, `curva`, etc.).
+   * Ascenso de nivel mediante los comandos `subir` / `volver`.
+4. **Verificación de Salida:** Confirmación visual en el árbol de FreeCAD y en los registros de DAV (`[DAV] OK (execute)` y procesamiento de `CreateObjects`).
+
+---
+
+## 3. Matriz de Resultados de Pruebas
+
+| Submódulo | Comando de Voz | Acción Ejecutada | Resultado en FreeCAD / DAV | Estado |
+| :--- | :--- | :--- | :--- | :---: |
+| **Círculo (`circle`)** | `"circulo"` → `"centro"` | `Executed center` | Geometría creada y descompuesta en vértices/aristas (`Extrusion`/`Circle`). | **APROBADO (OK)** ✅ |
+| **Arco (`arc`)** | `"arco"` → `"centro"` / `"puntos"` | `Executed center` / `Executed points` | Creación de arcos por centro y por 3 puntos interactivos. | **APROBADO (OK)** ✅ |
+| **Elipse (`ellipse`)** | `"elipse"` → `"elipse"` | `Executed center` | Creación de elipse en el plano de trabajo. | **APROBADO (OK)** ✅ |
+| **Curvas (`curve`)** | `"curva"` → `"bezier"` | `Executed bezier` | Creación de curva Bézier (`BezCurve`). | **APROBADO (OK)** ✅ |
+| **Colocación de puntos (`pointplacement`)** | `"colocación de puntos"` → `"punto en coordenadas"` | `Executed pointatcoords` | Punto creado en coordenadas absolutas `(7.0, 5.0, 8.0)`. | **APROBADO (OK)** ✅ |
+| **Conectar puntos (`pointconnect`)** | `"conectar puntos"` → `"conectar"` | `Executed connect` | Conexión y enlace de puntos seleccionados. | **APROBADO (OK)** ✅ |
+| **Matriz / Patrón (`circular_array`)** | `"matriz"` → `"circular"` / `"matriz polar"` | `Executed circular` / `Executed polar` | Matriz polar creada (114 líneas y 76 puntos asociados). | **APROBADO (OK)** ✅ |
+| **Anotaciones (`annotation`)** | `"anotación"` → `"editor"` | `Executed editor` | Apertura del diálogo de estilos de anotación. | **APROBADO (OK)** ✅ |
+| **Dimensiones (`dimension`)** | `"dimensión"` → `"dimension"` | `Executed linear` | Activación de herramienta de acotado lineal. | **APROBADO (OK)** ✅ |
+| **Modificaciones (`modify`)** | `"modificar"` → `"clonar"`, `"mover"`, `"rotar"`, `"espejo"`, `"desfase"`, `"boceto"` | `Executed clone`, `move`, `rotate`, `mirror`, `offset`, `sketch` | Operaciones de modificación y conversión aplicadas a objetos activos. | **APROBADO (OK)** ✅ |
+| **Aglutinante de Caras (`facebinder`)** | `"unir caras"` → `"crear"` / `"unir caras"` | `Executed create` | Creación exitosa de superficie `Facebinder`. | **APROBADO (OK)** ✅ |
+
+---
+
+## 4. Conclusiones y Observaciones
+* **Operatividad total:** Todas las herramientas probadas del módulo `DraftWork` funcionaron sin excepciones de código ni bloqueos en FreeCAD.
+* **Navegación limpia:** El sistema de navegación de subcontextos respetó la convención de submenús anidados (Rule 4), permitiendo descender y ascender sin colisiones de palabras clave.
+* **Integración de accesibilidad:** El subsistema `CreateObjects` reconoció y descompuso automáticamente las geometrías generadas en puntos y aristas para futura navegación por voz.


### PR DESCRIPTION
## Descripción
Este PR agrega el informe de validación y pruebas de todas las geometrías y herramientas del banco de trabajo Draft (`DraftWork`) en FreeCAD a través del sistema de navegación por voz de DAV.

## Submódulos Validados
- [x] Círculo (`circle`) - `centro`
- [x] Arco (`arc`) - `centro`, `puntos`
- [x] Elipse (`ellipse`) - `centro`
- [x] Curvas (`curve`) - `bezier`
- [x] Colocación de puntos (`pointplacement`) - `punto en coordenadas`
- [x] Conexión de puntos (`pointconnect`) - `conectar`
- [x] Matriz / Patrones (`circular_array`) - `circular`, `matriz polar`
- [x] Anotaciones (`annotation`) - `editor`
- [x] Dimensiones (`dimension`) - `lineal`
- [x] Modificaciones (`modify`) - `clonar`, `mover`, `rotar`, `espejo`, `desfase`, `boceto`
- [x] Aglutinante de Caras (`facebinder`) - `crear`