### PR TITLE
PartDesign: cortes y acabados por medida dictada + guias de prueba

### DIFF
--- a/Dav/dic/Workbench/PartDesign/modify/TraduceToEn.py
+++ b/Dav/dic/Workbench/PartDesign/modify/TraduceToEn.py
@@ -39,6 +39,19 @@ TraduceToEn = {
     "thickness": modify["thickness"],
     "shell": modify["thickness"],
 
+    # Dress-ups by dictated measure (no dialog)
+    "fillet by radius":      modify["fillet_by_radius"],
+    "round edges":           modify["fillet_by_radius"],
+
+    "chamfer by size":       modify["chamfer_by_size"],
+    "bevel by size":         modify["chamfer_by_size"],
+
+    "chamfer by size and angle": modify["chamfer_by_size_and_angle"],
+    "chamfer with angle":    modify["chamfer_by_size_and_angle"],
+
+    "thickness by value":    modify["thickness_by_value"],
+    "hollow solid":          modify["thickness_by_value"],
+
     # Help
     "help":            modify['help'],
     "info":            modify['help'],

--- a/Dav/dic/Workbench/PartDesign/modify/TraduceToEs.py
+++ b/Dav/dic/Workbench/PartDesign/modify/TraduceToEs.py
@@ -42,6 +42,21 @@ TraduceToEs = {
     "agregar espesor": modify["thickness"],
     "agregar grosor": modify["thickness"],
 
+    # Acabados por medida dictada (sin dialogo)
+    "redondear por radio":   modify["fillet_by_radius"],
+    "redondeo por radio":    modify["fillet_by_radius"],
+    "redondear aristas":     modify["fillet_by_radius"],
+
+    "chaflan por medida":    modify["chamfer_by_size"],
+    "achaflanar por medida": modify["chamfer_by_size"],
+    "chaflan por tamano":    modify["chamfer_by_size"],
+
+    "chaflan por medida y angulo": modify["chamfer_by_size_and_angle"],
+    "chaflan con angulo":    modify["chamfer_by_size_and_angle"],
+
+    "espesor por medida":    modify["thickness_by_value"],
+    "vaciar solido":         modify["thickness_by_value"],
+
     # Help
     "ayuda":                modify["help"],
     "información":          modify["help"],

--- a/Dav/dic/Workbench/PartDesign/modify/TraduceToPt.py
+++ b/Dav/dic/Workbench/PartDesign/modify/TraduceToPt.py
@@ -45,6 +45,18 @@ TraduceToPt = {
     "adicionar espessura": modify["thickness"],
     "adicionar casca": modify["thickness"],
 
+    # Acabamentos por medida ditada (sem dialogo)
+    "arredondar por raio":   modify["fillet_by_radius"],
+    "arredondar arestas":    modify["fillet_by_radius"],
+
+    "chanfro por medida":    modify["chamfer_by_size"],
+    "chanfrar por medida":   modify["chamfer_by_size"],
+
+    "chanfro por medida e angulo": modify["chamfer_by_size_and_angle"],
+
+    "espessura por medida":  modify["thickness_by_value"],
+    "esvaziar solido":       modify["thickness_by_value"],
+
     # Help
     "ajuda":             modify["help"],
     "informação":       modify["help"],

--- a/Dav/dic/Workbench/PartDesign/modify/_parametric.py
+++ b/Dav/dic/Workbench/PartDesign/modify/_parametric.py
@@ -1,0 +1,213 @@
+# Copyright (C) 2026 El Equipo del Proyecto DAV
+# Universidad Autónoma de Entre Ríos (UADER)
+# Bajo la dirección de Guillermo Gerard y Gallo Fabricio David
+#
+# Este programa es software libre: usted puede redistribuirlo y/o modificarlo
+# bajo los términos de la Licencia Pública General GNU tal como fue publicada
+# por la Fundación para el Software Libre, en la versión 3 de la Licencia.
+#
+# Este programa se distribuye con la esperanza de que sea útil,
+# pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+# MERCANTIBILIDAD o APTITUD PARA UN PROPÓSITO PARTICULAR. Consulte la
+# Licencia Pública General GNU para más detalles.
+#
+# Deberías haber recibido una copia de la Licencia Pública General GNU
+# junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Parametric dress-up commands for Validator (numbers and objects)."""
+
+from __future__ import annotations
+
+import FreeCAD as App
+import FreeCADGui as Gui
+
+
+def _RegisterObject(Feature) -> None:
+    """Register a created feature in the DAV navigable object tree."""
+    try:
+        from createobjects import CreateObjects
+    except ImportError:
+        from selection.createobjects import CreateObjects
+    CreateObjects(ObjectName=Feature.Name, Is3D=True).Execute()
+
+
+def _SelectedSolid(Doc):
+    """Return the solid to dress up: the selection, or the active object."""
+    try:
+        selection = Gui.Selection.getSelection()
+    except Exception:
+        selection = []
+    if selection:
+        return selection[0]
+    return getattr(Doc, "ActiveObject", None)
+
+
+def _OwningBody(Doc, Solid):
+    """Return the body that owns Solid, or None when it belongs to none."""
+    for obj in Doc.Objects:
+        if obj.isDerivedFrom("PartDesign::Body") and Solid in obj.Group:
+            return obj
+    return None
+
+
+def _ApplyDressUp(TypeId: str, Label: str, Doc, Solid):
+    """Create a dress-up feature covering every edge of Solid.
+
+    Picking individual edges by voice is impractical, so ``UseAllEdges`` is
+    switched on and the base is set with an empty subelement list -- the
+    combination FreeCAD's own tests use to dress a whole solid.
+
+    Args:
+        TypeId: FreeCAD type, e.g. ``PartDesign::Fillet``.
+        Label: Name used for the created object and log lines.
+        Doc: Active FreeCAD document.
+        Solid: Object whose edges are dressed.
+
+    Returns:
+        The created feature, or None when it could not be built.
+    """
+    feature = Doc.addObject(TypeId, Label)
+    feature.Base = (Solid, [""])
+    feature.UseAllEdges = True
+
+    body = _OwningBody(Doc, Solid)
+    if body is not None:
+        body.addObject(feature)
+    return feature
+
+
+def fillet_by_radius(radius: float) -> None:
+    """Round every edge of the selected solid by a dictated radius.
+
+    Args:
+        radius: Fillet radius, in millimetres. Must be greater than zero and
+            smaller than half the solid's smallest side, or the recompute
+            fails.
+
+    Example::
+
+        fillet_by_radius(3)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[modify] Error: no active document.")
+        return
+    if radius <= 0:
+        print(f"[modify] Error: radius must be greater than zero (got {radius}).")
+        return
+
+    solid = _SelectedSolid(doc)
+    if solid is None:
+        print("[modify] Error: select the solid to round first.")
+        return
+
+    fillet = _ApplyDressUp("PartDesign::Fillet", "Fillet", doc, solid)
+    fillet.Radius = radius
+
+    doc.recompute()
+    _RegisterObject(fillet)
+    print(f"[modify] Rounded '{solid.Name}' with radius {radius}")
+
+
+def chamfer_by_size(size: float) -> None:
+    """Chamfer every edge of the selected solid by a dictated size.
+
+    The chamfer angle stays at FreeCAD's 45 degree default; use
+    ``chamfer_by_size_and_angle`` to dictate it.
+
+    Args:
+        size: Chamfer size, in millimetres. Must be greater than zero.
+
+    Example::
+
+        chamfer_by_size(2)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[modify] Error: no active document.")
+        return
+    if size <= 0:
+        print(f"[modify] Error: size must be greater than zero (got {size}).")
+        return
+
+    solid = _SelectedSolid(doc)
+    if solid is None:
+        print("[modify] Error: select the solid to chamfer first.")
+        return
+
+    chamfer = _ApplyDressUp("PartDesign::Chamfer", "Chamfer", doc, solid)
+    chamfer.Size = size
+
+    doc.recompute()
+    _RegisterObject(chamfer)
+    print(f"[modify] Chamfered '{solid.Name}' with size {size}")
+
+
+def chamfer_by_size_and_angle(size: float, angle: float) -> None:
+    """Chamfer every edge of the selected solid by a dictated size and angle.
+
+    Args:
+        size: Chamfer size, in millimetres.
+        angle: Chamfer angle, in degrees. Must be between 0 and 180.
+
+    Example::
+
+        chamfer_by_size_and_angle(2, 30)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[modify] Error: no active document.")
+        return
+    if size <= 0:
+        print(f"[modify] Error: size must be greater than zero (got {size}).")
+        return
+    if angle <= 0 or angle >= 180:
+        print(f"[modify] Error: angle must be between 0 and 180 (got {angle}).")
+        return
+
+    solid = _SelectedSolid(doc)
+    if solid is None:
+        print("[modify] Error: select the solid to chamfer first.")
+        return
+
+    chamfer = _ApplyDressUp("PartDesign::Chamfer", "Chamfer", doc, solid)
+    chamfer.Size = size
+    # ChamferType 1 = "size and angle"; con el default (0) FreeCAD ignora Angle
+    chamfer.ChamferType = 1
+    chamfer.Angle = angle
+
+    doc.recompute()
+    _RegisterObject(chamfer)
+    print(f"[modify] Chamfered '{solid.Name}' with size {size} at {angle} degrees")
+
+
+def thickness_by_value(value: float) -> None:
+    """Hollow the selected solid leaving a dictated wall thickness.
+
+    Args:
+        value: Wall thickness, in millimetres. Must be greater than zero.
+
+    Example::
+
+        thickness_by_value(2)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[modify] Error: no active document.")
+        return
+    if value <= 0:
+        print(f"[modify] Error: thickness must be greater than zero (got {value}).")
+        return
+
+    solid = _SelectedSolid(doc)
+    if solid is None:
+        print("[modify] Error: select the solid to hollow first.")
+        return
+
+    thickness = _ApplyDressUp("PartDesign::Thickness", "Thickness", doc, solid)
+    thickness.Value = value
+
+    doc.recompute()
+    _RegisterObject(thickness)
+    print(f"[modify] Hollowed '{solid.Name}' leaving {value} of wall")

--- a/Dav/dic/Workbench/PartDesign/modify/modify.py
+++ b/Dav/dic/Workbench/PartDesign/modify/modify.py
@@ -1,6 +1,12 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 from .ayuda import ayuda
+from ._parametric import (
+    chamfer_by_size,
+    chamfer_by_size_and_angle,
+    fillet_by_radius,
+    thickness_by_value,
+)
 
 
 def _execute_with_objects(command_name: str, is_3d: bool = True) -> None:
@@ -32,5 +38,9 @@ modify = {
     'chamfer':   chamfer,
     'draft':     lambda: Gui.runCommand('PartDesign_Draft', 0),
     'thickness': lambda: Gui.runCommand('PartDesign_Thickness', 0),
+    'fillet_by_radius':          fillet_by_radius,
+    'chamfer_by_size':           chamfer_by_size,
+    'chamfer_by_size_and_angle': chamfer_by_size_and_angle,
+    'thickness_by_value':        thickness_by_value,
     'help':      ayuda,
 }

--- a/Dav/dic/Workbench/PartDesign/subtractive/TraduceToEn.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/TraduceToEn.py
@@ -84,6 +84,15 @@ TraduceToEn = {
     "booleanoperation": subtractive["boolean"],
     "booleanop": subtractive["boolean"],
 
+    # Cuts by dictated measure (no dialog)
+    "pocket by length":      subtractive["pocket_by_length"],
+    "hollow by length":      subtractive["pocket_by_length"],
+
+    "hole by size":          subtractive["hole_by_size"],
+    "drill by size":         subtractive["hole_by_size"],
+
+    "groove by angle":       subtractive["groove_by_angle"],
+
     # Help
     "help": subtractive['help'],
     "info": subtractive['help'],

--- a/Dav/dic/Workbench/PartDesign/subtractive/TraduceToEs.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/TraduceToEs.py
@@ -69,6 +69,18 @@ TraduceToEs = {
     "booleano": subtractive["boolean"],
     "operacion booleana": subtractive["boolean"],
 
+    # Cortes por medida dictada (sin dialogo)
+    "vaciado por medida":    subtractive["pocket_by_length"],
+    "vaciar por medida":     subtractive["pocket_by_length"],
+    "hueco por medida":      subtractive["pocket_by_length"],
+
+    "agujero por medidas":   subtractive["hole_by_size"],
+    "perforar por medidas":  subtractive["hole_by_size"],
+    "agujero por diametro":  subtractive["hole_by_size"],
+
+    "ranura por angulo":     subtractive["groove_by_angle"],
+    "ranurar por angulo":    subtractive["groove_by_angle"],
+
     # Help
     "ayuda": subtractive['help'],
     "información": subtractive['help'],

--- a/Dav/dic/Workbench/PartDesign/subtractive/TraduceToPt.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/TraduceToPt.py
@@ -82,6 +82,15 @@ TraduceToPt = {
     "booleano": subtractive["boolean"],
     "operação booleana": subtractive["boolean"],
 
+    # Cortes por medida ditada (sem dialogo)
+    "vazio por medida":      subtractive["pocket_by_length"],
+    "esvaziar por medida":   subtractive["pocket_by_length"],
+
+    "furo por medidas":      subtractive["hole_by_size"],
+    "perfurar por medidas":  subtractive["hole_by_size"],
+
+    "ranhura por angulo":    subtractive["groove_by_angle"],
+
     # Help
     "ajuda": subtractive['help'],
     "informação": subtractive['help'],

--- a/Dav/dic/Workbench/PartDesign/subtractive/_parametric.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/_parametric.py
@@ -1,0 +1,220 @@
+# Copyright (C) 2026 El Equipo del Proyecto DAV
+# Universidad Autónoma de Entre Ríos (UADER)
+# Bajo la dirección de Guillermo Gerard y Gallo Fabricio David
+#
+# Este programa es software libre: usted puede redistribuirlo y/o modificarlo
+# bajo los términos de la Licencia Pública General GNU tal como fue publicada
+# por la Fundación para el Software Libre, en la versión 3 de la Licencia.
+#
+# Este programa se distribuye con la esperanza de que sea útil,
+# pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+# MERCANTIBILIDAD o APTITUD PARA UN PROPÓSITO PARTICULAR. Consulte la
+# Licencia Pública General GNU para más detalles.
+#
+# Deberías haber recibido una copia de la Licencia Pública General GNU
+# junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Parametric subtractive commands for Validator (numbers and objects)."""
+
+from __future__ import annotations
+
+import FreeCAD as App
+import FreeCADGui as Gui
+
+
+def _RegisterObject(Feature) -> None:
+    """Register a created feature in the DAV navigable object tree."""
+    try:
+        from createobjects import CreateObjects
+    except ImportError:
+        from selection.createobjects import CreateObjects
+    CreateObjects(ObjectName=Feature.Name, Is3D=True).Execute()
+
+
+def _SelectedOrActive(Doc):
+    """Return the current selection, falling back to the active object."""
+    try:
+        selection = Gui.Selection.getSelection()
+    except Exception:
+        selection = []
+    if selection:
+        return selection[0]
+    return getattr(Doc, "ActiveObject", None)
+
+
+def _SketchFromShape(Doc, Source, Name: str):
+    """Copy a flat Part shape's edges into a new Sketcher object.
+
+    Same conversion used by the additive commands: PartDesign only cuts with a
+    ``Sketcher::SketchObject`` profile, while the DAV geometry commands produce
+    loose ``Part::Feature`` objects.
+
+    Args:
+        Doc: Active FreeCAD document.
+        Source: Object whose ``Shape`` edges are copied.
+        Name: Internal name for the new sketch.
+
+    Returns:
+        The created sketch, or None when Source carries no usable geometry.
+    """
+    shape = getattr(Source, "Shape", None)
+    if shape is None or not shape.Edges:
+        return None
+
+    sketch = Doc.addObject("Sketcher::SketchObject", Name)
+    for edge in shape.Edges:
+        try:
+            sketch.addGeometry(edge.Curve, False)
+        except Exception as error:
+            # una arista no convertible no invalida el resto del perfil
+            print(f"[subtractive] Skipped an edge while building the sketch: {error}")
+    return sketch
+
+
+def _ResolveProfile(Doc, Target):
+    """Return a usable profile for Target, converting a Part shape if needed."""
+    if Target is None:
+        return None
+    if Target.isDerivedFrom("Sketcher::SketchObject"):
+        return Target
+    return _SketchFromShape(Doc, Target, f"{Target.Name}Profile")
+
+
+def _OwningBody(Doc, Profile):
+    """Return the body that owns Profile, or a new one when there is none."""
+    for obj in Doc.Objects:
+        if obj.isDerivedFrom("PartDesign::Body") and Profile in obj.Group:
+            return obj
+    body = Doc.addObject("PartDesign::Body", "Body")
+    body.addObject(Profile)
+    return body
+
+
+def pocket_by_length(length: float) -> None:
+    """Cut a pocket into the body using the selected profile and a dictated depth.
+
+    The subtractive counterpart of ``pad_by_length``: instead of adding
+    material it removes it, so a square on a face becomes a square hollow.
+
+    Args:
+        length: Cut depth, in millimetres. Must be greater than zero.
+
+    Example::
+
+        pocket_by_length(10)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[subtractive] Error: no active document.")
+        return
+    if length <= 0:
+        print(f"[subtractive] Error: length must be greater than zero (got {length}).")
+        return
+
+    target = _SelectedOrActive(doc)
+    if target is None:
+        print("[subtractive] Error: select a 2D profile to cut with first.")
+        return
+
+    profile = _ResolveProfile(doc, target)
+    if profile is None:
+        print(f"[subtractive] Error: '{getattr(target, 'Name', target)}' has no usable outline.")
+        return
+
+    body = _OwningBody(doc, profile)
+
+    pocket = doc.addObject("PartDesign::Pocket", "Pocket")
+    pocket.Profile = profile
+    pocket.Length = length
+    body.addObject(pocket)
+
+    doc.recompute()
+    _RegisterObject(pocket)
+    print(f"[subtractive] Pocketed '{profile.Name}' by {length}")
+
+
+def hole_by_size(diameter: float, depth: float) -> None:
+    """Drill a hole using the selected circular profile and dictated measures.
+
+    Args:
+        diameter: Hole diameter, in millimetres.
+        depth: Hole depth, in millimetres.
+
+    Example::
+
+        hole_by_size(6, 25)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[subtractive] Error: no active document.")
+        return
+    if diameter <= 0 or depth <= 0:
+        print("[subtractive] Error: diameter and depth must be greater than zero.")
+        return
+
+    target = _SelectedOrActive(doc)
+    if target is None:
+        print("[subtractive] Error: select a circular profile to drill first.")
+        return
+
+    profile = _ResolveProfile(doc, target)
+    if profile is None:
+        print(f"[subtractive] Error: '{getattr(target, 'Name', target)}' has no usable outline.")
+        return
+
+    body = _OwningBody(doc, profile)
+
+    hole = doc.addObject("PartDesign::Hole", "Hole")
+    hole.Profile = profile
+    # ThreadType 0 = sin rosca; DepthType 1 = profundidad explicita en Depth,
+    # si se deja en 0 ("hasta el final") FreeCAD ignora el valor dictado.
+    hole.ThreadType = 0
+    hole.DepthType = 1
+    hole.Diameter = diameter
+    hole.Depth = depth
+    body.addObject(hole)
+
+    doc.recompute()
+    _RegisterObject(hole)
+    print(f"[subtractive] Drilled a hole of diameter {diameter} and depth {depth}")
+
+
+def groove_by_angle(angle: float) -> None:
+    """Cut a groove by revolving the selected profile a dictated angle.
+
+    Args:
+        angle: Sweep angle, in degrees. Must be between 0 and 360.
+
+    Example::
+
+        groove_by_angle(90)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[subtractive] Error: no active document.")
+        return
+    if angle <= 0 or angle > 360:
+        print(f"[subtractive] Error: angle must be between 0 and 360 (got {angle}).")
+        return
+
+    target = _SelectedOrActive(doc)
+    if target is None:
+        print("[subtractive] Error: select a 2D profile to groove with first.")
+        return
+
+    profile = _ResolveProfile(doc, target)
+    if profile is None:
+        print(f"[subtractive] Error: '{getattr(target, 'Name', target)}' has no usable outline.")
+        return
+
+    body = _OwningBody(doc, profile)
+
+    groove = doc.addObject("PartDesign::Groove", "Groove")
+    groove.Profile = profile
+    groove.Angle = angle
+    body.addObject(groove)
+
+    doc.recompute()
+    _RegisterObject(groove)
+    print(f"[subtractive] Grooved '{profile.Name}' by {angle} degrees")

--- a/Dav/dic/Workbench/PartDesign/subtractive/subtractive.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/subtractive.py
@@ -16,6 +16,7 @@
 
 import FreeCADGui as Gui
 from .ayuda import ayuda
+from ._parametric import groove_by_angle, hole_by_size, pocket_by_length
 
 subtractive = {
     'pocket':               lambda: Gui.runCommand('PartDesign_Pocket', 0),
@@ -32,6 +33,9 @@ subtractive = {
     'subtractivesphere':    lambda: Gui.runCommand('PartDesign_SubtractiveSphere', 0),
     'subtractivetorus':     lambda: Gui.runCommand('PartDesign_SubtractiveTorus', 0),
     'subtractivewedge':     lambda: Gui.runCommand('PartDesign_SubtractiveWedge', 0),
+    'pocket_by_length': pocket_by_length,
+    'hole_by_size':     hole_by_size,
+    'groove_by_angle':  groove_by_angle,
     'boolean':              lambda: Gui.runCommand('PartDesign_Boolean', 0),
     'help':                 ayuda,
 }

--- a/Dav/docs/guia-pruebas-3d-voz.md
+++ b/Dav/docs/guia-pruebas-3d-voz.md
@@ -1,0 +1,257 @@
+# Guía de pruebas — de un cuadrado a un ensamblaje, por voz
+
+Esta guía cubre lo agregado en los PR **#208**, **#209** y **#213**: crear
+geometría dictando medidas, extruirla a 3D y unir piezas con juntas — todo sin
+diálogos de FreeCAD.
+
+Todas las frases de esta guía están tomadas de los diccionarios reales
+(`Dav/dic/`). Ninguna es inventada.
+
+---
+
+## Antes de empezar
+
+- Abrí FreeCAD con el panel DAV, idioma **español**.
+- Tené un documento nuevo abierto.
+- Si te perdés: decí **`donde estoy`** — lista el contexto actual y las
+  opciones disponibles.
+- Para subir un nivel: **`subir`** (también `volver`, `atras`).
+
+**Confirmar un valor** (después de cada número):
+`enter` · `enviar` · `aceptar` · `confirmar` · `ok`
+
+**Abortar un pop-up**: `cancelar`
+
+### Los números llegan hasta 99
+
+El diccionario tiene 0–30 directos, más las decenas (40, 50, 60, 70, 80, 90).
+Los intermedios se dicen compuestos: `treinta y cinco`.
+
+**No existe «cien».** Usá valores de 0 a 99 en todas las pruebas.
+
+Otros modificadores:
+
+| Para decir | Decí |
+|---|---|
+| −20 | `menos veinte` |
+| 12,5 | `doce coma cinco` |
+
+---
+
+## Cómo reportar
+
+Para cada prueba anotá:
+
+1. **Qué dijiste** (la frase exacta).
+2. **Qué salió en el Report View** — todos los comandos imprimen ahí, tanto el
+   éxito como el error.
+3. **Si el objeto apareció en el árbol** del panel DAV.
+
+---
+
+## Prueba 1 — Cubo directo
+
+La más rápida. Confirma que la navegación, el pop-up y los números funcionan.
+
+| Decí | Qué pasa |
+|---|---|
+| `banco de trabajo` | entra a los workbenches |
+| `diseño de pieza` | entra a PartDesign |
+| `aditivo` | entra a las operaciones aditivas |
+| `caja por medidas` | **abre el pop-up** |
+| `veinte enter` | largo |
+| `veinte enter` | ancho |
+| `veinte enter` | alto |
+
+**Esperado**: un cubo de 20×20×20 y en el Report View:
+`[additive] Created box 20 x 20 x 20`
+
+> Si esta prueba falla, el problema es la navegación o el reconocimiento de
+> números. No sigas con las demás hasta resolverlo.
+
+---
+
+## Prueba 2 — Cilindro
+
+Desde `aditivo`:
+
+| Decí | Qué pasa |
+|---|---|
+| `cilindro por medidas` | abre el pop-up |
+| `diez enter` | radio |
+| `cuarenta enter` | altura |
+
+**Esperado**: cilindro r=10, h=40.
+
+---
+
+## Prueba 3 — El flujo completo: cuadrado → cubo
+
+**Ésta es la prueba principal.** Cierra el camino 2D → 3D sin mouse.
+
+### Paso A — dibujar el cuadrado
+
+| Decí | Qué pasa |
+|---|---|
+| `banco de trabajo` | |
+| `croquis` | entra a Sketcher |
+| `geometria` | entra a las geometrías |
+| `rectangulo` | entra al submenú rectángulo |
+| `rectangulo por esquinas` | **abre el pop-up** |
+| `cero enter` | x1 |
+| `cero enter` | y1 |
+| `veinte enter` | x2 |
+| `veinte enter` | y2 |
+
+**Esperado**: cuadrado de 20×20 y
+`[geometry.rectangle] Created 'Rectangle' from (0,0) to (20,20)`
+
+### Paso B — seleccionarlo
+
+Hacé clic en el rectángulo (en el árbol de objetos o en la vista 3D).
+
+> Este paso **todavía necesita mouse**. La selección por voz existe, pero es
+> otro flujo.
+
+### Paso C — extruirlo
+
+| Decí | Qué pasa |
+|---|---|
+| `subir` (hasta el nivel de workbench) | |
+| `diseño de pieza` | |
+| `aditivo` | |
+| `extruir por medida` | **abre el pop-up** |
+| `treinta enter` | altura |
+
+**Esperado**: el cuadrado se convierte en un prisma de 20×20×30 y
+`[additive] Padded '...' by 30`
+
+> **El paso más importante de probar.** Internamente el cuadrado (un
+> `Part::Feature`) se convierte a croquis para poder extruirse. Esa conversión
+> sólo se validó con stubs, nunca dentro de FreeCAD.
+
+---
+
+## Prueba 4 — Revolución
+
+Con un perfil 2D seleccionado, desde `aditivo`:
+
+| Decí | Qué pasa |
+|---|---|
+| `revolucion por angulo` | abre el pop-up |
+| `noventa enter` | ángulo en grados |
+
+**Esperado**: sólido de revolución de 90°.
+
+---
+
+## Prueba 5 — Otras geometrías 2D
+
+Desde `croquis` → `geometria`:
+
+| Figura | Decí | Valores de ejemplo |
+|---|---|---|
+| Círculo | `circulo` → `circulo por centro` | `cero` / `cero` / `veinticinco` |
+| Arco | `arco` → `arco por centro` | `cero` / `cero` / `veinticinco` / `cero` / `noventa` |
+| Elipse | `elipse` → `elipse por centro` | `cero` / `cero` / `cuarenta` / `veinte` |
+| Polígono | `poligono` → `poligono por lados` | `seis` / `cero` / `cero` / `veinticinco` |
+| Línea | `linea` → `linea por puntos` | `cero` / `cero` / `treinta` / `treinta` |
+
+---
+
+## Prueba 6 — Ensamblaje con juntas
+
+| Decí | Qué pasa |
+|---|---|
+| `banco de trabajo` | |
+| `ensamblaje` | entra a Assembly |
+| `crear ensamblaje` | crea el ensamblaje |
+| `insertar pieza` | inserta una pieza (repetir para tener dos) |
+
+Con **una pieza** seleccionada:
+
+| Decí | Esperado |
+|---|---|
+| `anclar pieza` | `[assembly] Grounded '...'` |
+
+Con **dos piezas** seleccionadas:
+
+| Decí | Luego | Esperado |
+|---|---|---|
+| `junta por distancia` | `veinticinco enter` | `Held '...' and '...' 25 apart` |
+| `junta por angulo` | `noventa enter` | `Held '...' and '...' at 90 degrees` |
+| `ensamble fijo` | — | `Fixed '...' to '...'` |
+| `bisagra` | — | `Hinged '...' to '...'` |
+| `junta deslizante` | — | `Slider between '...' and '...'` |
+
+Para verificar que el solver corre: `resolver ensamblaje`.
+
+> Seleccionar las piezas todavía necesita mouse; las juntas en sí ya no.
+
+---
+
+## Prueba 7 — Que los errores avisen
+
+Estas rutas están implementadas pero **no se probaron dentro de FreeCAD**.
+Confirmá que el mensaje sale en el Report View:
+
+| Prueba | Cómo | Mensaje esperado |
+|---|---|---|
+| Radio cero | `circulo por centro` → `cero`/`cero`/`cero` | `radius must be greater than zero` |
+| Polígono imposible | `poligono por lados` → `dos` | `a polygon needs at least 3 sides` |
+| Caja con lado cero | `caja por medidas` → `veinte`/`cero`/`veinte` | `every dimension must be greater than zero` |
+| Junta sin selección | `ensamble fijo` sin seleccionar nada | `select two parts to join first` |
+| Cancelar | en cualquier pop-up decí `cancelar` | `Command cancelled by user` |
+| Negativos | `menos veinte enter` | acepta −20 |
+| Decimales | `doce coma cinco enter` | acepta 12,5 |
+
+---
+
+## Prueba 8 — El bug del árbol de objetos
+
+Verifica una corrección puntual: antes, las elipses y polígonos creados por voz
+**no aparecían en el árbol** del panel DAV.
+
+1. Creá una **elipse** (prueba 5).
+2. Creá un **polígono**.
+3. Mirá el árbol de objetos del panel DAV.
+
+**Esperado**: ambos figuran en el árbol. Si no aparecen, el arreglo no funcionó.
+
+---
+
+## Prueba 9 — Los otros idiomas
+
+Tres módulos tenían diccionarios que fallaban en silencio: el loader aísla el
+módulo roto y sigue con mapa vacío, así que las frases simplemente no
+respondían, sin ningún error visible.
+
+Cambiá el idioma del panel y probá que respondan:
+
+| Idioma | Frase | Debería |
+|---|---|---|
+| Inglés | `box by size` | abrir el pop-up de la caja |
+| Inglés | `line by points` | abrir el pop-up de la línea |
+| Portugués | `caixa por medidas` | abrir el pop-up de la caja |
+| Portugués | `junta fixa` | crear una junta fija |
+
+Las de PartDesign en inglés y **todo Assembly en portugués** estaban caídos
+antes de estos cambios.
+
+---
+
+## Dónde es más probable que falle
+
+Nada de esto se ejecutó dentro de FreeCAD: se validó con stubs, que confirman
+el ruteo de las frases, la matemática y que los valores dictados llegan a las
+propiedades correctas — pero no la interacción con FreeCAD vivo.
+
+Los tres puntos de mayor riesgo:
+
+1. **Paso C de la prueba 3** — la conversión de cuadrado a croquis.
+   `addGeometry` con curvas reales puede comportarse distinto que con el stub.
+2. **Las juntas de la prueba 6** — se usa `Vertex1` de cada pieza como punto de
+   anclaje por defecto; con formas complejas puede no ser el punto esperado.
+3. **La cadena de navegación completa** — que
+   `banco de trabajo` → `diseño de pieza` → `aditivo` funcione de corrido con
+   el reconocimiento de voz real, no sólo en el diccionario.

--- a/Dav/docs/guia-pruebas-partdesign-voz.md
+++ b/Dav/docs/guia-pruebas-partdesign-voz.md
@@ -1,0 +1,239 @@
+# Guía de pruebas — PartDesign por voz
+
+Cubre los comandos de PartDesign que aceptan **medidas dictadas**: crear sólidos,
+extruir perfiles, cortarlos y darles acabado, sin abrir los diálogos de FreeCAD.
+
+Todas las frases están tomadas de los diccionarios reales (`Dav/dic/`).
+
+Para el flujo completo desde el dibujo 2D y para Assembly, ver
+[guia-pruebas-3d-voz.md](guia-pruebas-3d-voz.md).
+
+---
+
+## Antes de empezar
+
+- FreeCAD con el panel DAV, idioma **español**, documento nuevo abierto.
+- Si te perdés: **`donde estoy`**. Para subir un nivel: **`subir`**.
+- **Confirmar un valor**: `enter` · `enviar` · `aceptar` · `confirmar` · `ok`
+- **Abortar un pop-up**: `cancelar`
+
+### Los números llegan hasta 99
+
+0–30 directos, más las decenas (40, 50, 60, 70, 80, 90). Los intermedios son
+compuestos: `treinta y cinco`. **No existe «cien».**
+
+| Para decir | Decí |
+|---|---|
+| −20 | `menos veinte` |
+| 12,5 | `doce coma cinco` |
+
+### Cómo llegar
+
+Todas las pruebas arrancan con:
+
+```
+banco de trabajo → diseño de pieza
+```
+
+Y desde ahí se entra a `aditivo`, `sustractivo` o `modificar`.
+
+---
+
+## Qué esperar de cada comando
+
+| Categoría | Comando de voz | Prompts | Qué hace |
+|---|---|---|---|
+| Aditivo | `caja por medidas` | 3 | caja / cubo |
+| Aditivo | `cilindro por medidas` | 2 | cilindro |
+| Aditivo | `extruir por medida` | 1 | perfil → sólido |
+| Aditivo | `revolucion por angulo` | 1 | perfil → revolución |
+| Sustractivo | `vaciado por medida` | 1 | hueco con forma del perfil |
+| Sustractivo | `agujero por medidas` | 2 | agujero cilíndrico |
+| Sustractivo | `ranura por angulo` | 1 | ranura por revolución |
+| Modificar | `redondear por radio` | 1 | redondea todas las aristas |
+| Modificar | `chaflan por medida` | 1 | achaflana todas las aristas |
+| Modificar | `chaflan con angulo` | 2 | chaflán con ángulo propio |
+| Modificar | `espesor por medida` | 1 | ahueca dejando pared |
+
+---
+
+## Prueba 1 — Cubo
+
+| Decí | Qué pasa |
+|---|---|
+| `banco de trabajo` → `diseño de pieza` → `aditivo` | |
+| `caja por medidas` | abre el pop-up |
+| `veinte enter` | largo |
+| `veinte enter` | ancho |
+| `veinte enter` | alto |
+
+**Esperado**: `[additive] Created box 20 x 20 x 20`
+
+> Empezá por acá: si falla, el problema es la navegación o los números, no los
+> comandos.
+
+---
+
+## Prueba 2 — Cilindro
+
+Desde `aditivo`:
+
+| Decí | Qué pasa |
+|---|---|
+| `cilindro por medidas` | abre el pop-up |
+| `diez enter` | radio |
+| `cuarenta enter` | altura |
+
+**Esperado**: `[additive] Created cylinder radius 10 height 40`
+
+---
+
+## Prueba 3 — Redondear el cubo
+
+Con el cubo de la prueba 1 **seleccionado** (clic en el árbol o la vista 3D):
+
+| Decí | Qué pasa |
+|---|---|
+| `subir` → `modificar` | entra a los acabados |
+| `redondear por radio` | abre el pop-up |
+| `tres enter` | radio |
+
+**Esperado**: todas las aristas redondeadas y
+`[modify] Rounded '...' with radius 3`
+
+> El radio debe ser **menor que la mitad del lado más chico** del sólido. Con un
+> cubo de 20, un radio de 3 anda; uno de 15 falla al recalcular.
+
+---
+
+## Prueba 4 — Chaflán
+
+Con un sólido seleccionado, desde `modificar`:
+
+| Decí | Luego | Esperado |
+|---|---|---|
+| `chaflan por medida` | `dos enter` | chaflán de 2 mm a 45° |
+| `chaflan con angulo` | `dos enter` / `treinta enter` | chaflán de 2 mm a 30° |
+
+**Esperado**: `[modify] Chamfered '...' with size 2` (o `... at 30 degrees`).
+
+---
+
+## Prueba 5 — Ahuecar
+
+Con un sólido seleccionado, desde `modificar`:
+
+| Decí | Qué pasa |
+|---|---|
+| `espesor por medida` | abre el pop-up |
+| `dos enter` | espesor de pared |
+
+**Esperado**: `[modify] Hollowed '...' leaving 2 of wall`
+
+---
+
+## Prueba 6 — Cortar (sustractivo)
+
+Estos comandos necesitan un **perfil 2D seleccionado**, igual que `extruir`.
+
+Primero dibujá un cuadrado chico:
+
+```
+subir → croquis → geometria → rectangulo → rectangulo por esquinas
+cero / cero / diez / diez
+```
+
+Seleccionalo, y desde `diseño de pieza` → `sustractivo`:
+
+| Decí | Luego | Esperado |
+|---|---|---|
+| `vaciado por medida` | `diez enter` | `Pocketed '...' by 10` |
+| `ranura por angulo` | `noventa enter` | `Grooved '...' by 90 degrees` |
+
+Para el agujero, dibujá un círculo y seleccionalo:
+
+| Decí | Luego | Esperado |
+|---|---|---|
+| `agujero por medidas` | `seis enter` / `veinticinco enter` | `Drilled a hole of diameter 6 and depth 25` |
+
+---
+
+## Prueba 7 — Flujo completo: cuadrado → cubo → redondeado
+
+Encadena todo. Es la prueba que más valor tiene.
+
+| Paso | Decí |
+|---|---|
+| 1 | `banco de trabajo` → `croquis` → `geometria` → `rectangulo` |
+| 2 | `rectangulo por esquinas` → `cero`/`cero`/`veinte`/`veinte` |
+| 3 | *(clic en el rectángulo para seleccionarlo)* |
+| 4 | `subir` hasta workbench → `diseño de pieza` → `aditivo` |
+| 5 | `extruir por medida` → `treinta enter` |
+| 6 | *(clic en el sólido)* |
+| 7 | `subir` → `modificar` → `redondear por radio` → `tres enter` |
+
+**Esperado**: un prisma de 20×20×30 con las aristas redondeadas.
+
+> Los pasos 3 y 6 **todavía necesitan mouse**. La selección por voz existe pero
+> es otro flujo.
+
+---
+
+## Prueba 8 — Que los errores avisen
+
+Implementadas pero **no probadas dentro de FreeCAD**. Confirmá que el mensaje
+sale en el Report View:
+
+| Prueba | Cómo | Mensaje esperado |
+|---|---|---|
+| Caja con lado cero | `caja por medidas` → `veinte`/`cero`/`veinte` | `every dimension must be greater than zero` |
+| Radio negativo | `redondear por radio` → `menos uno` | `radius must be greater than zero` |
+| Chaflán cero | `chaflan por medida` → `cero` | `size must be greater than zero` |
+| Ángulo imposible | `chaflan con angulo` → `dos` / `doscientos` | `angle must be between 0 and 180` |
+| Sin selección | `redondear por radio` sin seleccionar nada | `select the solid to round first` |
+| Cancelar | `cancelar` en cualquier pop-up | `Command cancelled by user` |
+
+---
+
+## Prueba 9 — Los otros idiomas
+
+PartDesign tenía tres carpetas con diccionarios que fallaban en silencio: el
+loader aísla el módulo roto y sigue con mapa vacío, así que las frases
+simplemente no respondían, sin error visible.
+
+| Idioma | Frase | Debería |
+|---|---|---|
+| Inglés | `box by size` | abrir el pop-up de la caja |
+| Inglés | `fillet by radius` | abrir el pop-up del redondeo |
+| Portugués | `caixa por medidas` | abrir el pop-up de la caja |
+| Portugués | `chanfro por medida` | abrir el pop-up del chaflán |
+
+---
+
+## Cómo reportar
+
+Para cada prueba: **qué dijiste**, **qué salió en el Report View** y **si el
+objeto apareció en el árbol** del panel DAV.
+
+---
+
+## Dónde es más probable que falle
+
+Nada de esto se ejecutó dentro de FreeCAD: se validó con stubs, que confirman el
+ruteo de las frases y que los valores dictados llegan a las propiedades
+correctas (`Pad.Length`, `Fillet.Radius`, `Chamfer.Angle`…), pero no la
+interacción con FreeCAD vivo.
+
+Los puntos de mayor riesgo:
+
+1. **Redondeo y chaflán** — se aplican a **todas las aristas** del sólido
+   (`UseAllEdges`), porque elegir aristas sueltas por voz no es práctico. Si el
+   radio o el tamaño es muy grande para la pieza, el recompute falla: es
+   comportamiento de FreeCAD, no del comando, pero conviene ver qué mensaje
+   aparece.
+2. **Sustractivo** — el perfil se convierte de `Part::Feature` a croquis, igual
+   que en `extruir`. Con curvas reales puede comportarse distinto que con el
+   stub.
+3. **`agujero por medidas`** — se fuerza `DepthType = 1` para que respete la
+   profundidad dictada; vale confirmar que el agujero sale con la profundidad
+   pedida y no pasante.


### PR DESCRIPTION
Continúa el #208, #209 y #213 (todos integrados). Completa **el lado que faltaba de PartDesign**.

## El problema

Lo aditivo ya aceptaba medidas por voz (#209), pero **lo sustractivo y los acabados seguían abriendo el diálogo de FreeCAD**. Es decir: se podía crear un cubo hablando, pero no redondearlo ni perforarlo.

Eso dejaba incompleta una frase textual del MVP: *"extrusión, chaflán y otras operaciones 3D sobre cuerpos"* — el chaflán no se podía completar por voz.

## Comandos nuevos

**Sustractivo:**

| Comando | Dicta | Resultado |
|---|---|---|
| `pocket_by_length` | length | vaciado con forma del perfil |
| `hole_by_size` | diameter, depth | agujero cilíndrico |
| `groove_by_angle` | angle | ranura por revolución |

**Acabados:**

| Comando | Dicta | Resultado |
|---|---|---|
| `fillet_by_radius` | radius | redondeo |
| `chamfer_by_size` | size | chaflán a 45° |
| `chamfer_by_size_and_angle` | size, angle | chaflán con ángulo propio |
| `thickness_by_value` | value | ahuecado |

## Decisiones de implementación

**Redondeo y chaflán aplican a todas las aristas.** Usan `UseAllEdges = True` con `Base = (sólido, [""])`, la combinación que emplean los tests de FreeCAD (`TestFillet.py`, `TestChamfer.py`) para vestir un sólido entero. Elegir aristas sueltas por voz no es practicable.

**Dos detalles de API** que ameritan el comentario que llevan en el código:

- El agujero fuerza `DepthType = 1`. Con el default, FreeCAD **ignora la profundidad dictada** y hace el agujero pasante.
- El chaflán con ángulo fuerza `ChamferType = 1`. Con el default, **ignora `Angle`**.

Ambos se detectaron leyendo `FeatureHole.cpp` y `FeatureChamfer.cpp`; sin eso los comandos habrían aceptado el valor por voz y lo habrían descartado en silencio.

## Guías de prueba para el equipo

Se agregan dos documentos:

- **`guia-pruebas-partdesign-voz.md`** — 9 pruebas de PartDesign, del cubo al flujo encadenado cuadrado → cubo → redondeado.
- **`guia-pruebas-3d-voz.md`** — el recorrido completo 2D → 3D → ensamblaje, cubriendo también lo de los PR anteriores.

Ambas con las frases verificadas contra los diccionarios, los mensajes esperados del Report View, pruebas de error y una sección final sobre dónde es más probable que falle.

## Verificación

Con stubs de FreeCAD: firmas (= cantidad de prompts), ruteo de las 20 frases nuevas en es/en/pt, que los valores dictados llegan a las propiedades correctas (`Pocket.Length`, `Hole.Diameter`/`Depth`/`DepthType`, `Fillet.Radius`, `Chamfer.Size`/`Angle`/`ChamferType`, `Thickness.Value`) y las 6 guardas de error. Los 18 diccionarios de PartDesign siguen cargando en los tres idiomas.

**No se ejecutó dentro de FreeCAD real.** Los puntos de mayor riesgo, ya anotados en las guías:

1. **Redondeo y chaflán** — si el radio o tamaño es grande para la pieza, el recompute falla. Es comportamiento de FreeCAD, no del comando, pero conviene ver qué mensaje aparece.
2. **Sustractivo** — el perfil se convierte de `Part::Feature` a croquis, igual que en `extruir`; con curvas reales puede comportarse distinto que con el stub.
3. **`agujero por medidas`** — confirmar que sale con la profundidad pedida y no pasante.