### PR TITLE
PartDesign: completar el dictado por voz (primitivas, cortes y patrones)

### DIFF
--- a/Dav/dic/Workbench/PartDesign/additive/TraduceToEn.py
+++ b/Dav/dic/Workbench/PartDesign/additive/TraduceToEn.py
@@ -105,6 +105,12 @@ TraduceToEn = {
     "revolve by angle": additive["revolve_by_angle"],
     "spin profile": additive["revolve_by_angle"],
 
+    # Primitives by dictated measures
+    "sphere by radius":      additive["sphere_by_radius"],
+    "cone by size":          additive["cone_by_size"],
+    "torus by size":         additive["torus_by_size"],
+    "prism by size":         additive["prism_by_size"],
+
     "help":            additive['help'],
     "info":            additive['help'],
     "options":         additive['help']

--- a/Dav/dic/Workbench/PartDesign/additive/TraduceToEs.py
+++ b/Dav/dic/Workbench/PartDesign/additive/TraduceToEs.py
@@ -155,6 +155,19 @@ TraduceToEs = {
     "revolver por angulo": additive["revolve_by_angle"],
     "girar perfil": additive["revolve_by_angle"],
 
+    # Primitivas por medidas dictadas
+    "esfera por radio":      additive["sphere_by_radius"],
+    "crear esfera por radio": additive["sphere_by_radius"],
+
+    "cono por medidas":      additive["cone_by_size"],
+    "crear cono por medidas": additive["cone_by_size"],
+
+    "toro por medidas":      additive["torus_by_size"],
+    "rosquilla por medidas": additive["torus_by_size"],
+
+    "prisma por medidas":    additive["prism_by_size"],
+    "crear prisma por medidas": additive["prism_by_size"],
+
     #Ayuda
     "ayuda":                additive["help"],
     "información":          additive["help"],

--- a/Dav/dic/Workbench/PartDesign/additive/TraduceToPt.py
+++ b/Dav/dic/Workbench/PartDesign/additive/TraduceToPt.py
@@ -107,6 +107,12 @@ TraduceToPt = {
     "revolucao por angulo": additive["revolve_by_angle"],
     "girar perfil": additive["revolve_by_angle"],
 
+    # Primitivas por medidas ditadas
+    "esfera por raio":       additive["sphere_by_radius"],
+    "cone por medidas":      additive["cone_by_size"],
+    "toro por medidas":      additive["torus_by_size"],
+    "prisma por medidas":    additive["prism_by_size"],
+
     "ajuda":             additive["help"],
     "informação":       additive["help"],
     "opções":            additive["help"]

--- a/Dav/dic/Workbench/PartDesign/additive/_parametric.py
+++ b/Dav/dic/Workbench/PartDesign/additive/_parametric.py
@@ -271,3 +271,144 @@ def loft_profiles(profile_a: object, profile_b: object) -> None:
         f"'{getattr(profile_a, 'Name', profile_a)}' and "
         f"'{getattr(profile_b, 'Name', profile_b)}'"
     )
+
+
+def sphere_by_radius(radius: float) -> None:
+    """Create a sphere from a dictated radius.
+
+    Args:
+        radius: Sphere radius, in millimetres.
+
+    Example::
+
+        sphere_by_radius(15)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[additive] Error: no active document.")
+        return
+    if radius <= 0:
+        print(f"[additive] Error: radius must be greater than zero (got {radius}).")
+        return
+
+    body = doc.addObject("PartDesign::Body", "Body")
+    sphere = doc.addObject("PartDesign::AdditiveSphere", "Sphere")
+    sphere.Radius = radius
+    body.addObject(sphere)
+
+    doc.recompute()
+    _RegisterObject(sphere)
+    print(f"[additive] Created sphere radius {radius}")
+
+
+def cone_by_size(radius1: float, radius2: float, height: float) -> None:
+    """Create a cone from two dictated radii and a height.
+
+    Say a second radius of zero for a sharp tip, or two different radii for a
+    truncated cone.
+
+    Args:
+        radius1: Bottom radius, in millimetres.
+        radius2: Top radius, in millimetres. Zero gives a sharp tip.
+        height: Cone height, in millimetres.
+
+    Example::
+
+        cone_by_size(10, 0, 25)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[additive] Error: no active document.")
+        return
+    if radius1 < 0 or radius2 < 0:
+        print("[additive] Error: radii cannot be negative.")
+        return
+    if radius1 == radius2:
+        print("[additive] Error: the two radii must differ; use a cylinder instead.")
+        return
+    if height <= 0:
+        print(f"[additive] Error: height must be greater than zero (got {height}).")
+        return
+
+    body = doc.addObject("PartDesign::Body", "Body")
+    cone = doc.addObject("PartDesign::AdditiveCone", "Cone")
+    cone.Radius1 = radius1
+    cone.Radius2 = radius2
+    cone.Height = height
+    body.addObject(cone)
+
+    doc.recompute()
+    _RegisterObject(cone)
+    print(f"[additive] Created cone radii {radius1}/{radius2} height {height}")
+
+
+def torus_by_size(radius1: float, radius2: float) -> None:
+    """Create a torus from a dictated ring radius and tube radius.
+
+    Args:
+        radius1: Ring radius (centre to tube centre), in millimetres.
+        radius2: Tube radius, in millimetres. Must be smaller than radius1.
+
+    Example::
+
+        torus_by_size(20, 5)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[additive] Error: no active document.")
+        return
+    if radius1 <= 0 or radius2 <= 0:
+        print("[additive] Error: both radii must be greater than zero.")
+        return
+    # con el tubo mas grueso que el anillo el toro se auto-interseca
+    if radius2 >= radius1:
+        print(
+            f"[additive] Error: the tube radius ({radius2}) must be smaller "
+            f"than the ring radius ({radius1})."
+        )
+        return
+
+    body = doc.addObject("PartDesign::Body", "Body")
+    torus = doc.addObject("PartDesign::AdditiveTorus", "Torus")
+    torus.Radius1 = radius1
+    torus.Radius2 = radius2
+    body.addObject(torus)
+
+    doc.recompute()
+    _RegisterObject(torus)
+    print(f"[additive] Created torus ring {radius1} tube {radius2}")
+
+
+def prism_by_size(sides: int, circumradius: float, height: float) -> None:
+    """Create a prism from a dictated side count, radius and height.
+
+    Args:
+        sides: Number of sides of the base polygon. Must be 3 or more.
+        circumradius: Centre-to-vertex radius of the base, in millimetres.
+        height: Prism height, in millimetres.
+
+    Example::
+
+        prism_by_size(6, 10, 30)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[additive] Error: no active document.")
+        return
+    if sides < 3:
+        print(f"[additive] Error: a prism needs at least 3 sides (got {sides}).")
+        return
+    if circumradius <= 0 or height <= 0:
+        print("[additive] Error: radius and height must be greater than zero.")
+        return
+
+    body = doc.addObject("PartDesign::Body", "Body")
+    prism = doc.addObject("PartDesign::AdditivePrism", "Prism")
+    prism.Polygon = sides
+    prism.Circumradius = circumradius
+    prism.Height = height
+    body.addObject(prism)
+
+    doc.recompute()
+    _RegisterObject(prism)
+    print(f"[additive] Created prism of {sides} sides radius {circumradius} height {height}")

--- a/Dav/dic/Workbench/PartDesign/additive/additive.py
+++ b/Dav/dic/Workbench/PartDesign/additive/additive.py
@@ -19,11 +19,15 @@ import FreeCADGui as Gui
 from .ayuda import ayuda
 from ._parametric import (
     box_by_size,
+    cone_by_size,
     cylinder_by_size,
     loft_profiles,
     pad_by_length,
     pad_sketch,
+    prism_by_size,
     revolve_by_angle,
+    sphere_by_radius,
+    torus_by_size,
 )
 
 
@@ -121,6 +125,10 @@ additive = {
     'box_by_size':       box_by_size,
     'cylinder_by_size':  cylinder_by_size,
     'revolve_by_angle':  revolve_by_angle,
+    'sphere_by_radius':  sphere_by_radius,
+    'cone_by_size':      cone_by_size,
+    'torus_by_size':     torus_by_size,
+    'prism_by_size':     prism_by_size,
     'loft_profiles':     loft_profiles,
     'help':              ayuda,
 }

--- a/Dav/dic/Workbench/PartDesign/subtractive/TraduceToEn.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/TraduceToEn.py
@@ -93,6 +93,11 @@ TraduceToEn = {
 
     "groove by angle":       subtractive["groove_by_angle"],
 
+    # Primitive cuts by dictated measures
+    "cut box by size":       subtractive["cut_box_by_size"],
+    "cut cylinder by size":  subtractive["cut_cylinder_by_size"],
+    "cut sphere by radius":  subtractive["cut_sphere_by_radius"],
+
     # Help
     "help": subtractive['help'],
     "info": subtractive['help'],

--- a/Dav/dic/Workbench/PartDesign/subtractive/TraduceToEs.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/TraduceToEs.py
@@ -81,6 +81,15 @@ TraduceToEs = {
     "ranura por angulo":     subtractive["groove_by_angle"],
     "ranurar por angulo":    subtractive["groove_by_angle"],
 
+    # Cortes con primitivas por medidas dictadas
+    "cortar caja por medidas":     subtractive["cut_box_by_size"],
+    "restar caja por medidas":     subtractive["cut_box_by_size"],
+
+    "cortar cilindro por medidas": subtractive["cut_cylinder_by_size"],
+    "restar cilindro por medidas": subtractive["cut_cylinder_by_size"],
+
+    "cortar esfera por radio":     subtractive["cut_sphere_by_radius"],
+
     # Help
     "ayuda": subtractive['help'],
     "información": subtractive['help'],

--- a/Dav/dic/Workbench/PartDesign/subtractive/TraduceToPt.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/TraduceToPt.py
@@ -91,6 +91,11 @@ TraduceToPt = {
 
     "ranhura por angulo":    subtractive["groove_by_angle"],
 
+    # Cortes com primitivas por medidas ditadas
+    "cortar caixa por medidas":    subtractive["cut_box_by_size"],
+    "cortar cilindro por medidas": subtractive["cut_cylinder_by_size"],
+    "cortar esfera por raio":      subtractive["cut_sphere_by_radius"],
+
     # Help
     "ajuda": subtractive['help'],
     "informação": subtractive['help'],

--- a/Dav/dic/Workbench/PartDesign/subtractive/_parametric.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/_parametric.py
@@ -218,3 +218,117 @@ def groove_by_angle(angle: float) -> None:
     doc.recompute()
     _RegisterObject(groove)
     print(f"[subtractive] Grooved '{profile.Name}' by {angle} degrees")
+
+
+def _CutPrimitive(TypeId: str, Label: str, Doc):
+    """Create a subtractive primitive inside the body being edited.
+
+    Args:
+        TypeId: FreeCAD type, e.g. ``PartDesign::SubtractiveBox``.
+        Label: Name used for the created object.
+        Doc: Active FreeCAD document.
+
+    Returns:
+        The created feature, or None when there is no body to cut from.
+    """
+    bodies = [obj for obj in Doc.Objects if obj.isDerivedFrom("PartDesign::Body")]
+    if not bodies:
+        print("[subtractive] Error: create a solid first; there is nothing to cut from.")
+        return None
+
+    # se corta del ultimo cuerpo creado, que es el que el usuario acaba de
+    # construir por voz
+    body = bodies[-1]
+    feature = Doc.addObject(TypeId, Label)
+    body.addObject(feature)
+    return feature
+
+
+def cut_box_by_size(length: float, width: float, height: float) -> None:
+    """Cut a box-shaped pocket out of the current solid.
+
+    Args:
+        length: Size along X, in millimetres.
+        width: Size along Y, in millimetres.
+        height: Size along Z, in millimetres.
+
+    Example::
+
+        cut_box_by_size(10, 10, 20)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[subtractive] Error: no active document.")
+        return
+    if length <= 0 or width <= 0 or height <= 0:
+        print("[subtractive] Error: every dimension must be greater than zero.")
+        return
+
+    box = _CutPrimitive("PartDesign::SubtractiveBox", "CutBox", doc)
+    if box is None:
+        return
+    box.Length = length
+    box.Width = width
+    box.Height = height
+
+    doc.recompute()
+    _RegisterObject(box)
+    print(f"[subtractive] Cut a box {length} x {width} x {height}")
+
+
+def cut_cylinder_by_size(radius: float, height: float) -> None:
+    """Cut a cylindrical pocket out of the current solid.
+
+    Args:
+        radius: Cut radius, in millimetres.
+        height: Cut height, in millimetres.
+
+    Example::
+
+        cut_cylinder_by_size(5, 20)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[subtractive] Error: no active document.")
+        return
+    if radius <= 0 or height <= 0:
+        print("[subtractive] Error: radius and height must be greater than zero.")
+        return
+
+    cylinder = _CutPrimitive("PartDesign::SubtractiveCylinder", "CutCylinder", doc)
+    if cylinder is None:
+        return
+    cylinder.Radius = radius
+    cylinder.Height = height
+
+    doc.recompute()
+    _RegisterObject(cylinder)
+    print(f"[subtractive] Cut a cylinder radius {radius} height {height}")
+
+
+def cut_sphere_by_radius(radius: float) -> None:
+    """Cut a spherical pocket out of the current solid.
+
+    Args:
+        radius: Cut radius, in millimetres.
+
+    Example::
+
+        cut_sphere_by_radius(8)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[subtractive] Error: no active document.")
+        return
+    if radius <= 0:
+        print(f"[subtractive] Error: radius must be greater than zero (got {radius}).")
+        return
+
+    sphere = _CutPrimitive("PartDesign::SubtractiveSphere", "CutSphere", doc)
+    if sphere is None:
+        return
+    sphere.Radius = radius
+
+    doc.recompute()
+    _RegisterObject(sphere)
+    print(f"[subtractive] Cut a sphere radius {radius}")

--- a/Dav/dic/Workbench/PartDesign/subtractive/subtractive.py
+++ b/Dav/dic/Workbench/PartDesign/subtractive/subtractive.py
@@ -16,7 +16,14 @@
 
 import FreeCADGui as Gui
 from .ayuda import ayuda
-from ._parametric import groove_by_angle, hole_by_size, pocket_by_length
+from ._parametric import (
+    cut_box_by_size,
+    cut_cylinder_by_size,
+    cut_sphere_by_radius,
+    groove_by_angle,
+    hole_by_size,
+    pocket_by_length,
+)
 
 subtractive = {
     'pocket':               lambda: Gui.runCommand('PartDesign_Pocket', 0),
@@ -36,6 +43,9 @@ subtractive = {
     'pocket_by_length': pocket_by_length,
     'hole_by_size':     hole_by_size,
     'groove_by_angle':  groove_by_angle,
+    'cut_box_by_size':      cut_box_by_size,
+    'cut_cylinder_by_size': cut_cylinder_by_size,
+    'cut_sphere_by_radius': cut_sphere_by_radius,
     'boolean':              lambda: Gui.runCommand('PartDesign_Boolean', 0),
     'help':                 ayuda,
 }

--- a/Dav/dic/Workbench/PartDesign/transform/TraduceToEn.py
+++ b/Dav/dic/Workbench/PartDesign/transform/TraduceToEn.py
@@ -46,6 +46,19 @@ TraduceToEn = {
 
     # Help
     "help": transform['help'],
+    # Patterns by dictated measure (no dialog)
+    "linear pattern by length":   transform["linear_pattern"],
+    "repeat in line":             transform["linear_pattern"],
+
+    "linear pattern by spacing":  transform["linear_pattern_by_spacing"],
+    "repeat every":               transform["linear_pattern_by_spacing"],
+
+    "polar pattern by angle":     transform["polar_pattern"],
+    "repeat in circle":           transform["polar_pattern"],
+
+    "scale by factor":            transform["scaled_by_factor"],
+    "scale solid":                transform["scaled_by_factor"],
+
     "info": transform['help'],
     "options": transform['help'],
 }

--- a/Dav/dic/Workbench/PartDesign/transform/TraduceToEs.py
+++ b/Dav/dic/Workbench/PartDesign/transform/TraduceToEs.py
@@ -45,6 +45,21 @@ TraduceToEs = {
     "redimensionar": transform["scaled"],
 
     # Ayuda
+    # Patrones por medida dictada (sin dialogo)
+    "patron lineal por medida":   transform["linear_pattern"],
+    "repetir en linea":           transform["linear_pattern"],
+    "patron lineal":              transform["linear_pattern"],
+
+    "patron lineal por separacion": transform["linear_pattern_by_spacing"],
+    "repetir cada":               transform["linear_pattern_by_spacing"],
+
+    "patron circular por medida": transform["polar_pattern"],
+    "patron polar por medida":    transform["polar_pattern"],
+    "repetir en circulo":         transform["polar_pattern"],
+
+    "escalar por factor":         transform["scaled_by_factor"],
+    "escalar solido":             transform["scaled_by_factor"],
+
     "ayuda": transform['help'],
     "información": transform['help'],
     "opciones": transform['help'],

--- a/Dav/dic/Workbench/PartDesign/transform/TraduceToPt.py
+++ b/Dav/dic/Workbench/PartDesign/transform/TraduceToPt.py
@@ -45,6 +45,17 @@ TraduceToPt = {
     "redimensionar": transform["scaled"],
 
     # Ajuda
+    # Padroes por medida ditada (sem dialogo)
+    "padrao linear por medida":   transform["linear_pattern"],
+    "repetir em linha":           transform["linear_pattern"],
+
+    "padrao linear por espacamento": transform["linear_pattern_by_spacing"],
+
+    "padrao circular por medida": transform["polar_pattern"],
+    "repetir em circulo":         transform["polar_pattern"],
+
+    "escalar por fator":          transform["scaled_by_factor"],
+
     "ajuda": transform['help'],
     "informação": transform['help'],
     "opções": transform['help'],

--- a/Dav/dic/Workbench/PartDesign/transform/_parametric.py
+++ b/Dav/dic/Workbench/PartDesign/transform/_parametric.py
@@ -1,0 +1,238 @@
+# Copyright (C) 2026 El Equipo del Proyecto DAV
+# Universidad Autónoma de Entre Ríos (UADER)
+# Bajo la dirección de Guillermo Gerard y Gallo Fabricio David
+#
+# Este programa es software libre: usted puede redistribuirlo y/o modificarlo
+# bajo los términos de la Licencia Pública General GNU tal como fue publicada
+# por la Fundación para el Software Libre, en la versión 3 de la Licencia.
+#
+# Este programa se distribuye con la esperanza de que sea útil,
+# pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+# MERCANTIBILIDAD o APTITUD PARA UN PROPÓSITO PARTICULAR. Consulte la
+# Licencia Pública General GNU para más detalles.
+#
+# Deberías haber recibido una copia de la Licencia Pública General GNU
+# junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Parametric transform commands for Validator (numbers and objects)."""
+
+from __future__ import annotations
+
+import FreeCAD as App
+import FreeCADGui as Gui
+
+
+def _RegisterObject(Feature) -> None:
+    """Register a created feature in the DAV navigable object tree."""
+    try:
+        from createobjects import CreateObjects
+    except ImportError:
+        from selection.createobjects import CreateObjects
+    CreateObjects(ObjectName=Feature.Name, Is3D=True).Execute()
+
+
+def _SelectedFeature(Doc):
+    """Return the feature to repeat: the selection, or the active object."""
+    try:
+        selection = Gui.Selection.getSelection()
+    except Exception:
+        selection = []
+    if selection:
+        return selection[0]
+    return getattr(Doc, "ActiveObject", None)
+
+
+def _OwningBody(Doc, Feature):
+    """Return the body that owns Feature, or None when it belongs to none."""
+    for obj in Doc.Objects:
+        if obj.isDerivedFrom("PartDesign::Body") and Feature in obj.Group:
+            return obj
+    return None
+
+
+def _AxisNamed(Doc, Name: str):
+    """Return one of the document's base axes by attribute name."""
+    return getattr(Doc, Name, None)
+
+
+def _BuildTransform(TypeId: str, Label: str, Doc, Feature):
+    """Create a transform feature repeating Feature.
+
+    Args:
+        TypeId: FreeCAD type, e.g. ``PartDesign::LinearPattern``.
+        Label: Name used for the created object and log lines.
+        Doc: Active FreeCAD document.
+        Feature: The feature to repeat.
+
+    Returns:
+        The created transform feature.
+    """
+    transform = Doc.addObject(TypeId, Label)
+    transform.Originals = [Feature]
+
+    body = _OwningBody(Doc, Feature)
+    if body is not None:
+        body.addObject(transform)
+    return transform
+
+
+def linear_pattern(occurrences: int, length: float) -> None:
+    """Repeat the selected feature along the X axis a dictated number of times.
+
+    ``occurrences`` is an int, so it is collected with IntegerInputPrompt while
+    the length uses FloatInputPrompt.
+
+    ``length`` is the distance covered by the whole pattern, not the gap
+    between copies: FreeCAD's default mode is "Extent", so five copies over
+    80 mm land 20 mm apart. Use ``linear_pattern_by_spacing`` to dictate the
+    gap instead.
+
+    Args:
+        occurrences: How many copies, counting the original. Must be 2 or more.
+        length: Overall pattern length, in millimetres.
+
+    Example::
+
+        linear_pattern(5, 80)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[transform] Error: no active document.")
+        return
+    if occurrences < 2:
+        print(f"[transform] Error: a pattern needs at least 2 copies (got {occurrences}).")
+        return
+    if length <= 0:
+        print(f"[transform] Error: length must be greater than zero (got {length}).")
+        return
+
+    feature = _SelectedFeature(doc)
+    if feature is None:
+        print("[transform] Error: select the feature to repeat first.")
+        return
+
+    pattern = _BuildTransform("PartDesign::LinearPattern", "LinearPattern", doc, feature)
+    pattern.Direction = (_AxisNamed(doc, "X_Axis"), [""])
+    pattern.Length = length
+    pattern.Occurrences = occurrences
+
+    doc.recompute()
+    _RegisterObject(pattern)
+    print(f"[transform] Repeated '{feature.Name}' {occurrences} times over {length}")
+
+
+def linear_pattern_by_spacing(occurrences: int, offset: float) -> None:
+    """Repeat the selected feature along X with a dictated gap between copies.
+
+    Args:
+        occurrences: How many copies, counting the original. Must be 2 or more.
+        offset: Distance between consecutive copies, in millimetres.
+
+    Example::
+
+        linear_pattern_by_spacing(5, 20)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[transform] Error: no active document.")
+        return
+    if occurrences < 2:
+        print(f"[transform] Error: a pattern needs at least 2 copies (got {occurrences}).")
+        return
+    if offset <= 0:
+        print(f"[transform] Error: spacing must be greater than zero (got {offset}).")
+        return
+
+    feature = _SelectedFeature(doc)
+    if feature is None:
+        print("[transform] Error: select the feature to repeat first.")
+        return
+
+    pattern = _BuildTransform("PartDesign::LinearPattern", "LinearPattern", doc, feature)
+    pattern.Direction = (_AxisNamed(doc, "X_Axis"), [""])
+    # Mode 1 = "Spacing"; con el default (Extent) FreeCAD deja Offset en solo
+    # lectura y se queda con Length, ignorando la separacion dictada.
+    pattern.Mode = 1
+    pattern.Offset = offset
+    pattern.Occurrences = occurrences
+
+    doc.recompute()
+    _RegisterObject(pattern)
+    print(f"[transform] Repeated '{feature.Name}' {occurrences} times every {offset}")
+
+
+def polar_pattern(occurrences: int, angle: float) -> None:
+    """Repeat the selected feature around the Z axis over a dictated angle.
+
+    Args:
+        occurrences: How many copies, counting the original. Must be 2 or more.
+        angle: Angle covered by the whole pattern, in degrees. Use 360 for a
+            full turn.
+
+    Example::
+
+        polar_pattern(6, 360)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[transform] Error: no active document.")
+        return
+    if occurrences < 2:
+        print(f"[transform] Error: a pattern needs at least 2 copies (got {occurrences}).")
+        return
+    if angle <= 0 or angle > 360:
+        print(f"[transform] Error: angle must be between 0 and 360 (got {angle}).")
+        return
+
+    feature = _SelectedFeature(doc)
+    if feature is None:
+        print("[transform] Error: select the feature to repeat first.")
+        return
+
+    pattern = _BuildTransform("PartDesign::PolarPattern", "PolarPattern", doc, feature)
+    pattern.Axis = (_AxisNamed(doc, "Z_Axis"), [""])
+    pattern.Angle = angle
+    pattern.Occurrences = occurrences
+
+    doc.recompute()
+    _RegisterObject(pattern)
+    print(f"[transform] Repeated '{feature.Name}' {occurrences} times over {angle} degrees")
+
+
+def scaled_by_factor(occurrences: int, factor: float) -> None:
+    """Scale the selected feature by a dictated factor.
+
+    Args:
+        occurrences: How many scaled copies, counting the original. Use 2 for a
+            single scaled copy.
+        factor: Scale factor of the last copy. Greater than 1 grows, between 0
+            and 1 shrinks.
+
+    Example::
+
+        scaled_by_factor(2, 2)
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[transform] Error: no active document.")
+        return
+    if occurrences < 2:
+        print(f"[transform] Error: scaling needs at least 2 copies (got {occurrences}).")
+        return
+    if factor <= 0:
+        print(f"[transform] Error: factor must be greater than zero (got {factor}).")
+        return
+
+    feature = _SelectedFeature(doc)
+    if feature is None:
+        print("[transform] Error: select the feature to scale first.")
+        return
+
+    scaled = _BuildTransform("PartDesign::Scaled", "Scaled", doc, feature)
+    scaled.Factor = factor
+    scaled.Occurrences = occurrences
+
+    doc.recompute()
+    _RegisterObject(scaled)
+    print(f"[transform] Scaled '{feature.Name}' by {factor}")

--- a/Dav/dic/Workbench/PartDesign/transform/transform.py
+++ b/Dav/dic/Workbench/PartDesign/transform/transform.py
@@ -1,11 +1,21 @@
 import FreeCADGui as Gui
 from .ayuda import ayuda
+from ._parametric import (
+    linear_pattern,
+    linear_pattern_by_spacing,
+    polar_pattern,
+    scaled_by_factor,
+)
 
 transform = {
     'linearpattern':  lambda: Gui.runCommand('PartDesign_LinearPattern', 0),
     'mirrored':       lambda: Gui.runCommand('PartDesign_Mirrored', 0),
     'polarpattern':   lambda: Gui.runCommand('PartDesign_PolarPattern', 0),
     'multitransform': lambda: Gui.runCommand('PartDesign_MultiTransform', 0),
-    'scaled':         lambda: Gui.runCommand('PartDesign_MultiTransform', 0),
+    'scaled':         lambda: Gui.runCommand('PartDesign_Scaled', 0),
+    'linear_pattern':            linear_pattern,
+    'linear_pattern_by_spacing': linear_pattern_by_spacing,
+    'polar_pattern':             polar_pattern,
+    'scaled_by_factor':          scaled_by_factor,
     'help':           ayuda,
 }

--- a/Dav/docs/guia-pruebas-partdesign-voz.md
+++ b/Dav/docs/guia-pruebas-partdesign-voz.md
@@ -47,13 +47,24 @@ Y desde ahí se entra a `aditivo`, `sustractivo` o `modificar`.
 | Aditivo | `cilindro por medidas` | 2 | cilindro |
 | Aditivo | `extruir por medida` | 1 | perfil → sólido |
 | Aditivo | `revolucion por angulo` | 1 | perfil → revolución |
+| Aditivo | `esfera por radio` | 1 | esfera |
+| Aditivo | `cono por medidas` | 3 | cono / tronco |
+| Aditivo | `toro por medidas` | 2 | toro |
+| Aditivo | `prisma por medidas` | 3 | prisma regular |
 | Sustractivo | `vaciado por medida` | 1 | hueco con forma del perfil |
 | Sustractivo | `agujero por medidas` | 2 | agujero cilíndrico |
 | Sustractivo | `ranura por angulo` | 1 | ranura por revolución |
+| Sustractivo | `cortar caja por medidas` | 3 | resta una caja |
+| Sustractivo | `cortar cilindro por medidas` | 2 | resta un cilindro |
+| Sustractivo | `cortar esfera por radio` | 1 | resta una esfera |
 | Modificar | `redondear por radio` | 1 | redondea todas las aristas |
 | Modificar | `chaflan por medida` | 1 | achaflana todas las aristas |
 | Modificar | `chaflan con angulo` | 2 | chaflán con ángulo propio |
 | Modificar | `espesor por medida` | 1 | ahueca dejando pared |
+| Transformar | `patron lineal por medida` | 2 | N copias en línea |
+| Transformar | `repetir cada` | 2 | N copias con separación |
+| Transformar | `patron circular por medida` | 2 | N copias en círculo |
+| Transformar | `escalar por factor` | 2 | escala el sólido |
 
 ---
 
@@ -179,7 +190,59 @@ Encadena todo. Es la prueba que más valor tiene.
 
 ---
 
-## Prueba 8 — Que los errores avisen
+## Prueba 8 — Más primitivas
+
+Desde `aditivo`, cada una abre su pop-up:
+
+| Decí | Valores | Resultado |
+|---|---|---|
+| `esfera por radio` | `quince` | esfera r=15 |
+| `cono por medidas` | `diez` / `cero` / `veinticinco` | cono con punta |
+| `cono por medidas` | `diez` / `cinco` / `veinticinco` | tronco de cono |
+| `toro por medidas` | `veinte` / `cinco` | toro (anillo 20, tubo 5) |
+| `prisma por medidas` | `seis` / `diez` / `treinta` | prisma hexagonal |
+
+> En el toro, el radio del tubo debe ser **menor** que el del anillo, o el
+> comando avisa y no crea nada.
+
+---
+
+## Prueba 9 — Restar primitivas
+
+Con un sólido ya creado, desde `sustractivo`:
+
+| Decí | Valores | Resultado |
+|---|---|---|
+| `cortar caja por medidas` | `diez` / `diez` / `veinte` | resta una caja |
+| `cortar cilindro por medidas` | `cinco` / `veinte` | resta un cilindro |
+| `cortar esfera por radio` | `ocho` | resta una esfera |
+
+Se restan del **último cuerpo creado**.
+
+---
+
+## Prueba 10 — Patrones y escalado
+
+Con una operación seleccionada (por ejemplo el agujero de la prueba 6), desde
+`transformar`:
+
+| Decí | Valores | Resultado |
+|---|---|---|
+| `patron lineal por medida` | `cinco` / `ochenta` | 5 copias repartidas en 80 mm |
+| `repetir cada` | `cinco` / `veinte` | 5 copias, una cada 20 mm |
+| `patron circular por medida` | `seis` / `trescientos sesenta`* | 6 copias en círculo completo |
+| `escalar por factor` | `dos` / `dos` | duplica el tamaño |
+
+\* **Ojo**: 360 supera el máximo de 99 del diccionario numérico. Probá con
+`noventa` mientras tanto — es una limitación conocida, no un fallo del comando.
+
+> La diferencia entre los dos patrones lineales: `patron lineal por medida`
+> reparte las copias a lo largo del **total** dictado; `repetir cada` usa el
+> valor como **separación entre copias**.
+
+---
+
+## Prueba 11 — Que los errores avisen
 
 Implementadas pero **no probadas dentro de FreeCAD**. Confirmá que el mensaje
 sale en el Report View:
@@ -195,7 +258,7 @@ sale en el Report View:
 
 ---
 
-## Prueba 9 — Los otros idiomas
+## Prueba 12 — Los otros idiomas
 
 PartDesign tenía tres carpetas con diccionarios que fallaban en silencio: el
 loader aísla el módulo roto y sigue con mapa vacío, así que las frases


### PR DESCRIPTION
Cierra **PartDesign**. Continúa el #208, #209, #213 y #215 (todos integrados).

Todo comando que gana algo con una medida dictada ahora la pide por voz. Quedan con diálogo solo los que no toman números (`body`, `croquis nuevo`, `clone`, `espejo`, `preferencias`) — ahí el diálogo es lo correcto.

## Comandos nuevos

**Aditivo — primitivas que faltaban:**

| Comando | Dicta |
|---|---|
| `sphere_by_radius` | radius |
| `cone_by_size` | radius1, radius2, height |
| `torus_by_size` | radius1, radius2 |
| `prism_by_size` | **sides (int)**, circumradius, height |

**Sustractivo — restar primitivas:**

| Comando | Dicta |
|---|---|
| `cut_box_by_size` | length, width, height |
| `cut_cylinder_by_size` | radius, height |
| `cut_sphere_by_radius` | radius |

**Transformar — la carpeta que seguía entera con diálogo:**

| Comando | Dicta |
|---|---|
| `linear_pattern` | **occurrences (int)**, length |
| `linear_pattern_by_spacing` | **occurrences (int)**, offset |
| `polar_pattern` | **occurrences (int)**, angle |
| `scaled_by_factor` | **occurrences (int)**, factor |

Los patrones usan `Originals` + `Direction`/`Axis` sobre los ejes base del documento, según el patrón de `PartDesignTests/TestLinearPattern.py`.

## Dos detalles de API

Comentados en el código, ambos habrían descartado el valor dictado en silencio:

- **`linear_pattern_by_spacing` fuerza `Mode = 1`** ("Spacing"). Con el default ("Extent"), FreeCAD deja `Offset` en solo lectura y usa `Length` — la separación dictada se perdía.
- **El toro valida que el radio del tubo sea menor que el del anillo**; al revés la figura se auto-interseca.

## Un bug corregido

`scaled` apuntaba a `PartDesign_MultiTransform` en vez de a `PartDesign_Scaled`: escalar y multi-transformar hacían exactamente lo mismo.

## Estado de PartDesign

**20 comandos** con dictado por voz, repartidos en las tres carpetas que toman medidas:

| Carpeta | Paramétricos |
|---|---|
| additive | 8 |
| subtractive | 6 |
| modify | 4 |
| transform | 4 |

## Documentación

`guia-pruebas-partdesign-voz.md` se amplía con las pruebas 8 a 10, incluyendo una nota honesta: **un patrón circular de 360° todavía no se puede dictar** porque el diccionario numérico corta en 99. Es una limitación conocida, no un fallo del comando — se prueba con `noventa` mientras tanto.

## Verificación

Con stubs de FreeCAD: firmas de los 20 comandos paramétricos, ruteo de las 25 frases nuevas en es/en/pt, que los valores dictados llegan a las propiedades correctas (`Sphere.Radius`, `Cone.Radius1`/`Radius2`, `Prism.Polygon`, `LinearPattern.Occurrences`/`Length`/`Offset`/`Mode`, `PolarPattern.Angle`, `Scaled.Factor`…) y las guardas de error nuevas. Los 18 diccionarios de PartDesign y los 6 workbenches del árbol siguen cargando.

**No se ejecutó dentro de FreeCAD real.** El punto más frágil son los patrones: dependen de que el documento tenga los ejes base (`X_Axis`, `Z_Axis`) y de que la operación seleccionada pertenezca a un body, algo que el stub no puede reproducir fielmente.