### PR TITLE
Assembly: completar las 13 juntas por voz + documentar el limite numerico

### DIFF
--- a/Dav/dic/Workbench/Assembly/Assembly.py
+++ b/Dav/dic/Workbench/Assembly/Assembly.py
@@ -19,10 +19,18 @@ from .joint.joint import joint
 from .ayuda import ayuda
 from ._parametric import (
     angle_joint,
+    ball_joint,
+    belt_joint,
+    cylindrical_joint,
     distance_joint,
     fixed_joint,
+    gears_joint,
     ground_part,
+    parallel_joint,
+    perpendicular_joint,
+    rack_pinion_joint,
     revolute_joint,
+    screw_joint,
     slider_joint,
 )
 
@@ -46,5 +54,13 @@ assembly.update({
     'distance_joint':  distance_joint,
     'angle_joint':     angle_joint,
     'ground_part':     ground_part,
+    'ball_joint':          ball_joint,
+    'cylindrical_joint':   cylindrical_joint,
+    'parallel_joint':      parallel_joint,
+    'perpendicular_joint': perpendicular_joint,
+    'gears_joint':         gears_joint,
+    'belt_joint':          belt_joint,
+    'screw_joint':         screw_joint,
+    'rack_pinion_joint':   rack_pinion_joint,
     'help':        ayuda,
 })

--- a/Dav/dic/Workbench/Assembly/TraduceToEn.py
+++ b/Dav/dic/Workbench/Assembly/TraduceToEn.py
@@ -62,6 +62,20 @@ TraduceToEn = {
     "ground part":           assembly["ground_part"],
     "anchor part":           assembly["ground_part"],
 
+    # Remaining voice joints
+    "ball joint":            assembly["ball_joint"],
+    "cylindrical joint":     assembly["cylindrical_joint"],
+    "parallel joint":        assembly["parallel_joint"],
+    "keep parallel":         assembly["parallel_joint"],
+    "perpendicular joint":   assembly["perpendicular_joint"],
+    "keep perpendicular":    assembly["perpendicular_joint"],
+
+    "gears joint":           assembly["gears_joint"],
+    "mesh gears":            assembly["gears_joint"],
+    "belt joint":            assembly["belt_joint"],
+    "screw joint":           assembly["screw_joint"],
+    "rack and pinion joint": assembly["rack_pinion_joint"],
+
     "help":            joint['help'],
     "info":            joint['help'],
     "options":         joint['help']

--- a/Dav/dic/Workbench/Assembly/TraduceToEs.py
+++ b/Dav/dic/Workbench/Assembly/TraduceToEs.py
@@ -120,6 +120,30 @@ TraduceToEs = {
     "anclar pieza":          assembly["ground_part"],
     "poner a tierra":        assembly["ground_part"],
 
+    # Juntas restantes por voz
+    "junta esferica":        assembly["ball_joint"],
+    "rotula":                assembly["ball_joint"],
+
+    "junta cilindrica":      assembly["cylindrical_joint"],
+
+    "junta paralela":        assembly["parallel_joint"],
+    "mantener paralelo":     assembly["parallel_joint"],
+
+    "junta perpendicular":   assembly["perpendicular_joint"],
+    "mantener perpendicular": assembly["perpendicular_joint"],
+
+    "junta de engranajes":   assembly["gears_joint"],
+    "engranar piezas":       assembly["gears_joint"],
+
+    "junta de correa":       assembly["belt_joint"],
+    "correa entre piezas":   assembly["belt_joint"],
+
+    "junta de tornillo":     assembly["screw_joint"],
+    "atornillar piezas":     assembly["screw_joint"],
+
+    "junta de cremallera":   assembly["rack_pinion_joint"],
+    "cremallera y pinon":    assembly["rack_pinion_joint"],
+
     # Ayuda
     "ayuda":            joint['help'],
     "información":            joint['help'],

--- a/Dav/dic/Workbench/Assembly/TraduceToPt.py
+++ b/Dav/dic/Workbench/Assembly/TraduceToPt.py
@@ -80,6 +80,18 @@ TraduceToPt = {
     "fixar ao chao":         assembly["ground_part"],
     "ancorar peca":          assembly["ground_part"],
 
+    # Juntas restantes por voz
+    "junta esferica":        assembly["ball_joint"],
+    "rotula":                assembly["ball_joint"],
+    "junta cilindrica":      assembly["cylindrical_joint"],
+    "junta paralela":        assembly["parallel_joint"],
+    "junta perpendicular":   assembly["perpendicular_joint"],
+
+    "junta de engrenagens":  assembly["gears_joint"],
+    "junta de correia":      assembly["belt_joint"],
+    "junta de parafuso":     assembly["screw_joint"],
+    "junta de cremalheira":  assembly["rack_pinion_joint"],
+
     "ajuda":               joint['help'],
     "informação":          joint['help'],
     "opções":              joint['help']

--- a/Dav/dic/Workbench/Assembly/_parametric.py
+++ b/Dav/dic/Workbench/Assembly/_parametric.py
@@ -35,6 +35,10 @@ _JOINT_TYPE_INDEX = {
     "Parallel": 6,
     "Perpendicular": 7,
     "Angle": 8,
+    "RackPinion": 9,
+    "Screw": 10,
+    "Gears": 11,
+    "Belt": 12,
 }
 
 
@@ -331,3 +335,167 @@ def ground_part() -> None:
     doc.recompute()
     _RegisterObject(feature)
     print(f"[assembly] Grounded '{parts[0].Name}'")
+
+
+def _SimpleJoint(JointTypeName: str, Verb: str) -> None:
+    """Create a joint that needs no dictated value between two selected parts.
+
+    Args:
+        JointTypeName: Key of ``_JOINT_TYPE_INDEX``.
+        Verb: Past-tense verb used in the log line.
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[assembly] Error: no active document.")
+        return
+
+    parts = _SelectedParts(2)
+    if parts is None:
+        print("[assembly] Error: select two parts to join first.")
+        return
+
+    joint = _CreateJoint(JointTypeName, doc, parts)
+    if joint is None:
+        return
+
+    doc.recompute()
+    _RegisterObject(joint)
+    print(f"[assembly] {Verb} '{parts[0].Name}' and '{parts[1].Name}'")
+
+
+def ball_joint() -> None:
+    """Join the two selected parts with a ball joint, free to rotate any way.
+
+    Example::
+
+        ball_joint()
+    """
+    _SimpleJoint("Ball", "Ball-jointed")
+
+
+def cylindrical_joint() -> None:
+    """Join the two selected parts so one both slides and turns on an axis.
+
+    Example::
+
+        cylindrical_joint()
+    """
+    _SimpleJoint("Cylindrical", "Cylindrically joined")
+
+
+def parallel_joint() -> None:
+    """Keep the two selected parts parallel to each other.
+
+    Example::
+
+        parallel_joint()
+    """
+    _SimpleJoint("Parallel", "Kept parallel")
+
+
+def perpendicular_joint() -> None:
+    """Keep the two selected parts perpendicular to each other.
+
+    Example::
+
+        perpendicular_joint()
+    """
+    _SimpleJoint("Perpendicular", "Kept perpendicular")
+
+
+def _RatioJoint(JointTypeName: str, Verb: str, Radius1: float, Radius2: float | None) -> None:
+    """Create a joint whose motion ratio comes from one or two dictated radii.
+
+    FreeCAD stores these in the generic ``Distance`` and ``Distance2``
+    properties rather than in fields of their own: ``Distance`` holds the pitch
+    radius (rack and pinion, screw, belt) or the first gear radius, and
+    ``Distance2`` the second gear radius.
+
+    Args:
+        JointTypeName: Key of ``_JOINT_TYPE_INDEX``.
+        Verb: Past-tense verb used in the log line.
+        Radius1: First radius or pitch, in millimetres.
+        Radius2: Second radius, or None when the joint uses only one.
+    """
+    doc = App.activeDocument()
+    if doc is None:
+        print("[assembly] Error: no active document.")
+        return
+    if Radius1 <= 0 or (Radius2 is not None and Radius2 <= 0):
+        print("[assembly] Error: radii must be greater than zero.")
+        return
+
+    parts = _SelectedParts(2)
+    if parts is None:
+        print("[assembly] Error: select two parts to join first.")
+        return
+
+    joint = _CreateJoint(JointTypeName, doc, parts)
+    if joint is None:
+        return
+
+    joint.Distance = Radius1
+    if Radius2 is not None:
+        joint.Distance2 = Radius2
+
+    doc.recompute()
+    _RegisterObject(joint)
+    sizes = f"{Radius1}" if Radius2 is None else f"{Radius1} and {Radius2}"
+    print(f"[assembly] {Verb} '{parts[0].Name}' and '{parts[1].Name}' with {sizes}")
+
+
+def gears_joint(radius1: float, radius2: float) -> None:
+    """Mesh the two selected parts as gears with dictated radii.
+
+    The ratio between the radii sets how fast one gear turns relative to the
+    other.
+
+    Args:
+        radius1: Radius of the first gear, in millimetres.
+        radius2: Radius of the second gear, in millimetres.
+
+    Example::
+
+        gears_joint(20, 10)
+    """
+    _RatioJoint("Gears", "Meshed", radius1, radius2)
+
+
+def belt_joint(radius1: float, radius2: float) -> None:
+    """Link the two selected parts with a belt between dictated pulley radii.
+
+    Args:
+        radius1: Radius of the first pulley, in millimetres.
+        radius2: Radius of the second pulley, in millimetres.
+
+    Example::
+
+        belt_joint(30, 15)
+    """
+    _RatioJoint("Belt", "Belted", radius1, radius2)
+
+
+def screw_joint(pitch: float) -> None:
+    """Join the two selected parts as a screw with a dictated pitch radius.
+
+    Args:
+        pitch: Pitch radius, in millimetres.
+
+    Example::
+
+        screw_joint(5)
+    """
+    _RatioJoint("Screw", "Screwed", pitch, None)
+
+
+def rack_pinion_joint(pitch_radius: float) -> None:
+    """Join the two selected parts as rack and pinion with a dictated radius.
+
+    Args:
+        pitch_radius: Pitch radius of the pinion, in millimetres.
+
+    Example::
+
+        rack_pinion_joint(10)
+    """
+    _RatioJoint("RackPinion", "Rack-and-pinioned", pitch_radius, None)

--- a/Dav/docs/guia-pruebas-3d-voz.md
+++ b/Dav/docs/guia-pruebas-3d-voz.md
@@ -22,12 +22,17 @@ Todas las frases de esta guía están tomadas de los diccionarios reales
 
 **Abortar un pop-up**: `cancelar`
 
-### Los números llegan hasta 99
+### Números: 0–99 se dicen normal, de 100 en adelante se deletrean
 
-El diccionario tiene 0–30 directos, más las decenas (40, 50, 60, 70, 80, 90).
-Los intermedios se dicen compuestos: `treinta y cinco`.
+Se pronuncian natural hasta 99: 0–30 directos, más las decenas (40, 50, 60, 70,
+80, 90) y los compuestos (`treinta y cinco`).
 
-**No existe «cien».** Usá valores de 0 a 99 en todas las pruebas.
+De 100 en adelante hay que **deletrear dígito por dígito**: `uno cero cero` da
+100, `tres seis cero` da 360. Funciona, pero es incómodo — ver
+[numeros-por-voz-limites-y-propuesta.md](numeros-por-voz-limites-y-propuesta.md).
+
+Las pruebas de esta guía usan valores menores a 100 para que las frases suenen
+naturales.
 
 Otros modificadores:
 
@@ -183,6 +188,24 @@ Con **dos piezas** seleccionadas:
 | `ensamble fijo` | — | `Fixed '...' to '...'` |
 | `bisagra` | — | `Hinged '...' to '...'` |
 | `junta deslizante` | — | `Slider between '...' and '...'` |
+
+**Juntas sin medidas** (dos piezas seleccionadas):
+
+| Decí | Qué hace |
+|---|---|
+| `rotula` | libre en cualquier rotación |
+| `junta cilindrica` | gira y desliza sobre un eje |
+| `junta paralela` | mantiene las piezas paralelas |
+| `junta perpendicular` | mantiene las piezas en ángulo recto |
+
+**Juntas de transmisión** (dos piezas seleccionadas, piden radios):
+
+| Decí | Luego | Qué hace |
+|---|---|---|
+| `junta de engranajes` | `veinte` / `diez` | engrana con esa relación |
+| `junta de correa` | `treinta` / `quince` | poleas unidas por correa |
+| `junta de tornillo` | `cinco` | avance de rosca |
+| `junta de cremallera` | `diez` | cremallera y piñón |
 
 Para verificar que el solver corre: `resolver ensamblaje`.
 

--- a/Dav/docs/guia-pruebas-partdesign-voz.md
+++ b/Dav/docs/guia-pruebas-partdesign-voz.md
@@ -17,10 +17,13 @@ Para el flujo completo desde el dibujo 2D y para Assembly, ver
 - **Confirmar un valor**: `enter` · `enviar` · `aceptar` · `confirmar` · `ok`
 - **Abortar un pop-up**: `cancelar`
 
-### Los números llegan hasta 99
+### Números: 0–99 se dicen normal, de 100 en adelante se deletrean
 
-0–30 directos, más las decenas (40, 50, 60, 70, 80, 90). Los intermedios son
-compuestos: `treinta y cinco`. **No existe «cien».**
+Se pronuncian natural hasta 99: 0–30 directos, más las decenas (40, 50, 60, 70,
+80, 90) y los compuestos (`treinta y cinco`).
+
+De 100 en adelante hay que **deletrear**: `uno cero cero` da 100. Ver
+[numeros-por-voz-limites-y-propuesta.md](numeros-por-voz-limites-y-propuesta.md).
 
 | Para decir | Decí |
 |---|---|
@@ -233,8 +236,9 @@ Con una operación seleccionada (por ejemplo el agujero de la prueba 6), desde
 | `patron circular por medida` | `seis` / `trescientos sesenta`* | 6 copias en círculo completo |
 | `escalar por factor` | `dos` / `dos` | duplica el tamaño |
 
-\* **Ojo**: 360 supera el máximo de 99 del diccionario numérico. Probá con
-`noventa` mientras tanto — es una limitación conocida, no un fallo del comando.
+\* **Ojo**: 360 no se puede pronunciar como palabra; hay que deletrearlo:
+`tres seis cero enter`. Funciona, pero es incómodo — está documentado en
+[numeros-por-voz-limites-y-propuesta.md](numeros-por-voz-limites-y-propuesta.md).
 
 > La diferencia entre los dos patrones lineales: `patron lineal por medida`
 > reparte las copias a lo largo del **total** dictado; `repetir cada` usa el

--- a/Dav/docs/numeros-por-voz-limites-y-propuesta.md
+++ b/Dav/docs/numeros-por-voz-limites-y-propuesta.md
@@ -1,0 +1,160 @@
+# Números por voz — qué se puede dictar hoy y cómo quitar el techo
+
+Estado del reconocimiento numérico en los pop-ups de parámetros
+(`SpokenNumberParser`), qué límite tiene realmente y qué haría falta para
+sacarlo.
+
+---
+
+## Lo que se puede dictar hoy
+
+Contra lo que se anotó en las primeras guías de prueba, **no hay un techo duro
+de 99**. El parser concatena dígitos, así que cualquier número es dictable
+deletreándolo:
+
+| Se dice | Se obtiene |
+|---|---|
+| `veinticinco` | 25 |
+| `treinta y cinco` | 35 |
+| `cinco cero` | 50 |
+| `nueve nueve` | 99 |
+| **`uno cero cero`** | **100** |
+| **`uno dos tres`** | **123** |
+| `menos veinte` | −20 |
+| `doce coma cinco` | 12,5 |
+
+Verificado ejecutando `SpokenNumberParser.ParseInteger` sobre cada frase.
+
+Lo que **sí** corta en 99 es la pronunciación *natural* de un número como
+palabra compuesta: «ciento veinticinco» no se entiende, porque `cien` y las
+centenas no están en el diccionario.
+
+### La consecuencia práctica
+
+Para valores de 0 a 99 se habla normal. Para 100 o más hay que **deletrear
+dígito por dígito**, que funciona pero es antinatural — sobre todo en casos
+como un patrón circular de 360°, donde `tres seis cero` es incómodo comparado
+con «trescientos sesenta».
+
+---
+
+## Por qué pasa
+
+`SpokenNumberParser.DigitWords` es un mapa plano de palabra → dígito, con 93
+entradas que cubren 0–30 y las decenas (40, 50, 60, 70, 80, 90) en los tres
+idiomas.
+
+`_MergeTensAndUnits` arma los compuestos de dos palabras («treinta y cinco» →
+35), pero **no hay noción de centena ni de multiplicador**: el parser junta
+dígitos en una cadena de texto en vez de sumar valores posicionales.
+
+```
+"uno cero cero"  →  "1" + "0" + "0"  →  "100"   (concatenación, no suma)
+```
+
+Por eso deletrear funciona y pronunciar no.
+
+---
+
+## Las tres salidas posibles
+
+### 1. Biblioteca externa
+
+`text2num` o `number_parser` resuelven esto con soporte es/en/pt.
+
+**No conviene.** El código corre en el **Python embebido de FreeCAD**, no en el
+venv de desarrollo. El proyecto hoy no tiene dependencias externas más allá de
+Vosk y PyAudio, y sumar uno más al intérprete embebido es frágil de instalar y
+de sostener en las máquinas del equipo.
+
+### 2. Algoritmo de composición posicional — recomendada
+
+El español, como el inglés y el portugués, construye números de forma
+**regular**: unidades, decenas, centenas y multiplicadores. No hay que
+enumerar mil palabras, sino unas 30 más las reglas de combinación.
+
+```
+valor = suma de grupos, con multiplicadores que cierran cada grupo
+
+"doscientos treinta y cinco"  →  200 + 30 + 5            =   235
+"tres mil cuatrocientos"      →  (3 × 1000) + 400        =  3400
+```
+
+Palabras base necesarias:
+
+| Grupo | Palabras |
+|---|---|
+| Unidades y 11–15 | `uno`…`quince` — **ya están** |
+| Decenas | `veinte`…`noventa` — **ya están** |
+| Centenas | `cien`, `ciento`, `doscientos`…`novecientos` — **faltan** |
+| Multiplicadores | `mil`, `millón` — **faltan** |
+
+Es decir: el diccionario ya tiene la mayor parte. Falta agregar centenas y
+multiplicadores, y reemplazar `_MergeTensAndUnits` por un acumulador que sume
+por posición en vez de concatenar texto.
+
+Son unas 60 líneas, sin dependencias nuevas, y la misma estructura sirve para
+los tres idiomas.
+
+### 3. Ampliar el hardcodeo
+
+Agregar `cien`, `doscientos`, etc. como entradas planas del mapa.
+
+Rápido, pero no escala: para llegar a 1.000.000 harían falta miles de entradas,
+y cada una infla la gramática de Vosk.
+
+---
+
+## El detalle que condiciona todo: la gramática de Vosk
+
+**El parser no alcanza por sí solo.** La gramática de Vosk se acota al contexto
+activo (ver [acortador-gramatica-vosk.md](acortador-gramatica-vosk.md)), y
+durante un pop-up numérico se cambia a la lista que devuelve
+`get_numeric_grammar_phrases()` en `Dav/dic/Numbers/Numbers.py`, vía
+`NumericGrammarSwitcher.ActivateNumericGrammar()`.
+
+Esa lista sale **del mismo diccionario** que alimenta al parser. O sea:
+
+> Si «doscientos» no está en el diccionario numérico, Vosk **nunca va a
+> transcribir esa palabra**, por más que el parser sepa interpretarla.
+
+Es una buena noticia de diseño: parser y gramática comparten fuente, así que
+agregar las palabras nuevas al diccionario las habilita en ambos lados a la
+vez. Pero implica que el cambio **no es sólo del parser** — hay que verificar
+que `get_numeric_grammar_phrases()` incluya las centenas y multiplicadores
+nuevos.
+
+---
+
+## Recomendación
+
+Encarar la **opción 2**, en este orden:
+
+1. Agregar centenas y multiplicadores al diccionario `Numbers`, en los tres
+   idiomas.
+2. Confirmar que `get_numeric_grammar_phrases()` los devuelva (si arma la lista
+   desde el mapa completo, sale gratis).
+3. Reemplazar `_MergeTensAndUnits` por un acumulador posicional.
+4. **Mantener el modo dígito-a-dígito**, que hoy funciona y puede haber gente
+   usándolo: el acumulador debería reconocer ambas formas.
+
+El punto 4 es el que más cuidado pide. Hoy `uno cero cero` da 100 por
+concatenación; un acumulador posicional ingenuo lo interpretaría como
+1 + 0 + 0 = 1. Hay que decidir explícitamente cómo convive cada modo antes de
+tocar el parser.
+
+---
+
+## Impacto actual
+
+Ningún comando está bloqueado —todo valor se puede deletrear— pero hay casos
+donde se nota:
+
+| Caso | Hoy | Con la propuesta |
+|---|---|---|
+| Patrón circular 360° | `tres seis cero` | `trescientos sesenta` |
+| Cota de 150 mm | `uno cinco cero` | `ciento cincuenta` |
+| Medidas 0–99 | ya es natural | igual |
+
+Mientras tanto, las guías de prueba usan valores menores a 100 para que las
+frases de ejemplo suenen naturales.


### PR DESCRIPTION
Cierra **Assembly**. Continúa el #213 y el #216 (integrados).

## Las 8 juntas que faltaban

Ya no abren diálogo.

**Sin medidas:**

| Comando | Qué hace |
|---|---|
| `ball_joint` | rótula, libre en cualquier rotación |
| `cylindrical_joint` | gira y desliza sobre un eje |
| `parallel_joint` | mantiene las piezas paralelas |
| `perpendicular_joint` | mantiene las piezas en ángulo recto |

**De transmisión, con radios dictados:**

| Comando | Dicta |
|---|---|
| `gears_joint` | radius1, radius2 |
| `belt_joint` | radius1, radius2 |
| `screw_joint` | pitch |
| `rack_pinion_joint` | pitch_radius |

Estas cuatro **no tienen propiedades propias**: FreeCAD las guarda en las genéricas `Distance` y `Distance2` (`Distance` = radio de paso o primer radio, `Distance2` = segundo radio del engranaje), según documenta `JointObject.addDistanceProperty`. Sin leer eso, habría buscado campos que no existen.

Con esto Assembly queda en **13 juntas** cubiertas, con el índice de tipo verificado uno por uno contra `JointTypes`.

## Corrección: el techo de 99 no existía

Se agrega `numeros-por-voz-limites-y-propuesta.md`, que corrige algo que **estas mismas guías venían afirmando mal**.

No hay un techo duro de 99. El parser concatena dígitos, así que:

```
'uno cero cero'  →  100
'uno dos tres'   →  123
```

Cualquier valor es dictable deletreándolo. Lo que corta en 99 es la **pronunciación natural** («ciento veinticinco»), porque faltan centenas y multiplicadores en el diccionario.

El documento propone resolverlo con un **acumulador posicional** (~60 líneas, sin dependencias nuevas) en vez de una biblioteca externa, que sería frágil de instalar en el Python embebido de FreeCAD. Y deja anotado el detalle que condiciona el cambio:

> La gramática de Vosk se alimenta del **mismo diccionario** que el parser (`get_numeric_grammar_phrases`). Si «doscientos» no está ahí, Vosk nunca lo va a transcribir, por más que el parser sepa interpretarlo.

También marca el riesgo de la migración: hoy `uno cero cero` da 100 por concatenación; un acumulador posicional ingenuo lo leería como 1+0+0=1. Hay que decidir explícitamente cómo conviven ambos modos.

Las dos guías de prueba se corrigen en consecuencia.

## Verificación

Con stubs: las 13 juntas creadas con el índice correcto (0=Fixed … 12=Belt), los valores dictados llegando a `Distance`/`Distance2`/`Angle`, las firmas (= cantidad de prompts), el ruteo de las 16 frases nuevas en es/en/pt y las guardas de error. Los 6 diccionarios de Assembly y los 6 workbenches del árbol siguen cargando.

**No se ejecutó dentro de FreeCAD real.** Sigue vigente lo señalado en el #213: `setJointConnectors` usa `Vertex1` de cada pieza como anclaje por defecto, y con formas complejas puede no ser el punto que el usuario espera.