### PR TITLE
 Sketcher: selección de plano por voz al crear nuevo boceto

### DIFF
--- a/Dav/dic/Workbench/Sketcher/Geometry/geometry.py
+++ b/Dav/dic/Workbench/Sketcher/Geometry/geometry.py
@@ -28,6 +28,7 @@ from .Polygon._polygon import polygon
 from .polyline.polyline import polyline
 from .rectangle.rectangle import rectangle
 from .ayuda import ayuda
+from ..new_sketch.new_sketch import _new_sketch
 
 geometry = {
     'arc': arc,
@@ -43,7 +44,7 @@ geometry = {
     'polyline': polyline,
     'rectangle': rectangle,
 
-    'new': lambda: Gui.runCommand('Sketcher_NewSketch', 0),
+    'new': _new_sketch,
     'edit': lambda: Gui.runCommand('Sketcher_EditSketch', 0),
     'attach': lambda: Gui.runCommand('Sketcher_MapSketch', 0),
     'grid': lambda: Gui.runCommand('Sketcher_Grid', 0),

--- a/Dav/dic/Workbench/Sketcher/TraduceToEs.py
+++ b/Dav/dic/Workbench/Sketcher/TraduceToEs.py
@@ -81,6 +81,9 @@ TraduceToEs = {
    "nuevo": sketcher["new"],
    "nuevo croquis": sketcher["new"],
    "crear croquis": sketcher["new"],
+   "nuevo boceto": sketcher["new"],
+   "crear boceto": sketcher["new"],
+   "boceto nuevo": sketcher["new"],
 
    "editar": sketcher["edit"],
    "editar croquis": sketcher["edit"],

--- a/Dav/dic/Workbench/Sketcher/new_sketch/new_sketch.py
+++ b/Dav/dic/Workbench/Sketcher/new_sketch/new_sketch.py
@@ -1,0 +1,132 @@
+# Copyright (C) 2026 El Equipo del Proyecto DAV
+# Universidad Autónoma de Entre Ríos (UADER)
+# Bajo la dirección de Guillermo Gerard y Gallo Fabricio David
+#
+# Este programa es software libre: usted puede redistribuirlo y/o modificarlo
+# bajo los términos de la Licencia Pública General GNU tal como fue publicada
+# por la Fundación para el Software Libre, en la versión 3 de la Licencia.
+#
+# Este programa se distribuye con la esperanza de que sea útil,
+# pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+# MERCANTIBILIDAD o APTITUD PARA UN PROPÓSITO PARTICULAR. Consulte la
+# Licencia Pública General GNU para más detalles.
+#
+# Deberías haber recibido una copia de la Licencia Pública General GNU
+# junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
+
+"""New sketch with a DAV voice-driven plane orientation selector.
+
+Reemplaza al diálogo nativo de FreeCAD (``Sketcher_NewSketch`` →
+``SketchOrientationDialog``), que no se puede controlar por voz. Al decir
+"nuevo boceto" se abre el selector DAV (``PlaneSelectionInputPrompt``) y el
+usuario elige el eje XY/XZ/YZ con "arriba"/"abajo" y confirma con
+"okey"/"cancelar". El boceto se crea sobre el plano elegido.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_input_prompts_on_path() -> None:
+    """Make ``InputPrompts`` importable regardless of the current working dir.
+
+    En runtime el motor vive dentro de FreeCAD con GUIFreeCad en sys.path,
+    pero los diccionarios pueden cargarse en contextos distintos (tests,
+    consola). Se busca ascendiendo hasta toparse con la carpeta InputPrompts.
+    """
+    if "InputPrompts" in sys.modules or any(
+        Path(p).name == "GUIFreeCad" for p in sys.path
+    ):
+        return
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "InputPrompts").is_dir():
+            text = str(parent)
+            if text not in sys.path:
+                sys.path.insert(0, text)
+            return
+
+
+def _import_plane_prompt():
+    _ensure_input_prompts_on_path()
+    from InputPrompts.PlaneSelectionInputPrompt import PlaneSelectionInputPrompt
+
+    return PlaneSelectionInputPrompt
+
+
+# Rotaciones (cuaternión w,x,y,z) idénticas a las que usa el diálogo nativo de
+# FreeCAD (SketchOrientationDialog) para cada plano, con MapMode Deactivated.
+_PLANE_ROTATIONS = {
+    "XY": (1.0, 0.0, 0.0, 0.0),
+    "XZ": (1.0, 0.0, 0.0, 1.0),
+    "YZ": (1.0, 1.0, 1.0, 1.0),
+}
+
+
+def _new_sketch() -> None:
+    """Ask the user (by voice) for the plane and create the sketch on it."""
+    import FreeCAD as App
+
+    result = _ask_plane()
+    if result is None or result.Cancelled or not result.Value:
+        print("[DAV] Nuevo boceto cancelado por el usuario.")
+        return
+
+    plane = str(result.Value).upper()
+    doc = App.activeDocument()
+    if doc is None:
+        doc = App.newDocument("SinTítulo")
+    if doc is None:
+        return
+
+    sketch = doc.addObject("Sketcher::SketchObject", _unique_sketch_name(doc))
+    rotation = _PLANE_ROTATIONS.get(plane, _PLANE_ROTATIONS["XY"])
+    # App.Rotation(q0, q1, q2, q3) = (w, x, y, z), igual que el nativo.
+    sketch.Placement = App.Placement(App.Vector(0, 0, 0), App.Rotation(*rotation))
+    sketch.MapMode = "Deactivated"
+    doc.recompute()
+
+    # Entrar al modo de edición del boceto recién creado, como hace el nativo.
+    try:
+        import FreeCADGui as Gui
+
+        Gui.activeDocument().setEdit(sketch.Name)
+    except Exception:
+        pass
+
+    print(f"[DAV] Nuevo boceto '{sketch.Name}' creado en el plano {plane}.")
+
+
+def _ask_plane():
+    """Show the DAV plane selector and route voice to it."""
+    try:
+        from InputPrompts.PromptVoiceRouter import PromptVoiceRouter
+    except ImportError:
+        _ensure_input_prompts_on_path()
+        from InputPrompts.PromptVoiceRouter import PromptVoiceRouter
+
+    PlanePrompt = _import_plane_prompt()
+    prompt = PlanePrompt()
+    PromptVoiceRouter.SetActivePrompt(prompt)
+    try:
+        return prompt.RequestValue()
+    finally:
+        PromptVoiceRouter.ClearActivePrompt(prompt)
+
+
+def _unique_sketch_name(doc) -> str:
+    """Return a document-unique name like 'Sketch' or 'Sketch001'."""
+    base = "Sketch"
+    if doc.getObject(base) is None:
+        return base
+    index = 1
+    while doc.getObject(f"{base}{index:03d}") is not None:
+        index += 1
+    return f"{base}{index:03d}"
+
+
+new_sketch = {
+    "new": lambda: _new_sketch(),
+}

--- a/Dav/dic/Workbench/Sketcher/new_sketch/new_sketch.py
+++ b/Dav/dic/Workbench/Sketcher/new_sketch/new_sketch.py
@@ -100,20 +100,31 @@ def _new_sketch() -> None:
 
 
 def _ask_plane():
-    """Show the DAV plane selector and route voice to it."""
+    """Show the DAV plane selector, route voice to it and acotar la gramática."""
     try:
         from InputPrompts.PromptVoiceRouter import PromptVoiceRouter
     except ImportError:
         _ensure_input_prompts_on_path()
         from InputPrompts.PromptVoiceRouter import PromptVoiceRouter
 
+    try:
+        from InputPrompts.PlaneGrammarSwitcher import PlaneGrammarSwitcher
+    except ImportError:
+        _ensure_input_prompts_on_path()
+        from InputPrompts.PlaneGrammarSwitcher import PlaneGrammarSwitcher
+
     PlanePrompt = _import_plane_prompt()
     prompt = PlanePrompt()
+    # Mientras el selector está abierto, Vosk solo escucha arriba/abajo/okey/
+    # cancelar: evita que "abajo" se confunda con "trabajo" u otros falsos
+    # positivos del vocabulario abierto.
+    PlaneGrammarSwitcher.ActivatePlaneGrammar()
     PromptVoiceRouter.SetActivePrompt(prompt)
     try:
         return prompt.RequestValue()
     finally:
         PromptVoiceRouter.ClearActivePrompt(prompt)
+        PlaneGrammarSwitcher.RestoreCadGrammar()
 
 
 def _unique_sketch_name(doc) -> str:

--- a/Dav/dic/Workbench/Sketcher/sketcher.py
+++ b/Dav/dic/Workbench/Sketcher/sketcher.py
@@ -32,6 +32,7 @@ from .oblong.oblong import oblong
 from .Root.root import root
 from .text.text import text
 from .slot.slot import slot
+from .new_sketch.new_sketch import _new_sketch
 from _lenient import LenientDict
 
 
@@ -69,7 +70,7 @@ sketcher.update({'triangle':    triangle})
 sketcher.update({'validate':    validate})
 sketcher.update({'view':        view})
 sketcher.update({
-    'new':                lambda: Gui.runCommand('Sketcher_NewSketch', 0),
+    'new':                _new_sketch,
     'edit':               lambda: Gui.runCommand('Sketcher_EditSketch', 0),
     'attach':             lambda: Gui.runCommand('Sketcher_MapSketch', 0),
     'grid':               lambda: Gui.runCommand('Sketcher_Grid', 0),

--- a/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/InputPrompts/PlaneGrammarSwitcher.py
+++ b/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/InputPrompts/PlaneGrammarSwitcher.py
@@ -1,0 +1,58 @@
+#  Copyright (C) 2026 The DAV Project Team
+#  Universidad Autónoma de Entre Ríos (UADER)
+#  SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Switches the active Vosk grammar in and out of plane-selection mode.
+
+El selector de plano (``PlaneSelectionInputPrompt``) solo necesita que Vosk
+escuche un puñado de palabras (arriba/abajo/okey/cancelar). Sin esto, el
+modelo abierto confunde "abajo" con "trabajo" y otros falsos positivos del
+vocabulario completo. Al activarse se acota la gramática a esas frases, y al
+cerrarse se restaura la gramática del contexto CAD.
+"""
+
+from __future__ import annotations
+
+
+# Frases mínimas por idioma para navegar el selector de plano. Se mantienen
+# deliberadamente chicas (es el punto de acotar): arriba/abajo para mover el
+# eje, okey para confirmar y cancelar para salir.
+_PLANE_PHRASES: dict[str, list[str]] = {
+    "es": ["arriba", "abajo", "okey", "ok", "aceptar", "cancelar"],
+    "en": ["up", "down", "okey", "ok", "accept", "cancel"],
+    "pt": ["cima", "abaixo", "okey", "ok", "aceitar", "cancelar"],
+}
+
+
+class PlaneGrammarSwitcher:
+    """Restricts Vosk grammar to the sketch plane selection words."""
+
+    @staticmethod
+    def PlanePhrases(Language: str = "es") -> list[str]:
+        """Return the plane-selection phrases for ``Language`` ("es"/"en"/"pt")."""
+        return list(_PLANE_PHRASES.get(Language, _PLANE_PHRASES["es"]))
+
+    @staticmethod
+    def ActivatePlaneGrammar() -> None:
+        """Restrict the Vosk grammar to the plane-selection words."""
+        try:
+            from core.settings import settings
+            from speech.dav_voice_service import DavVoiceService
+
+            DavVoiceService.get().set_grammar(
+                PlaneGrammarSwitcher.PlanePhrases(settings.language)
+            )
+        except Exception:
+            # Sin gramática acotada el reconocimiento sigue andando, solo con
+            # el vocabulario abierto: se nota, no se derriba el selector.
+            pass
+
+    @staticmethod
+    def RestoreCadGrammar() -> None:
+        """Restore the Vosk grammar for the active Browser context."""
+        try:
+            from InputPrompts.NumericGrammarSwitcher import NumericGrammarSwitcher
+
+            NumericGrammarSwitcher.RestoreCadGrammar()
+        except Exception:
+            pass

--- a/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/InputPrompts/PlaneSelectionInputPrompt.py
+++ b/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/InputPrompts/PlaneSelectionInputPrompt.py
@@ -1,0 +1,126 @@
+#  Copyright (C) 2026 The DAV Project Team
+#  Universidad Autónoma de Entre Ríos (UADER)
+#  SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Voice-driven sketch plane orientation selector for DAV."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from InputPrompts.BaseInputPrompt import BaseInputPrompt
+from InputPrompts.PromptResult import PromptResult
+from InputPrompts.SpokenNumberParser import SpokenNumberParser
+
+
+class PlaneSelectionInputPrompt(BaseInputPrompt):
+    """Prompt to choose the sketch plane orientation (XY / XZ / YZ) by voice.
+
+    Replaces FreeCAD's native ``SketchOrientationDialog`` when creating a new
+    sketch, because that dialog is not reachable from the DAV voice pipeline.
+    The user browses the three axes with ``arriba``/``abajo`` (up/down),
+    highlights the current selection, and confirms an axis with ``okey``/
+    ``ok``/``aceptar`` or cancels with ``cancelar``.
+
+    The accepted value is one of the plane keys ``XY``, ``XZ`` or ``YZ``.
+    """
+
+    PlaneKeys: tuple[str, ...] = ("XY", "XZ", "YZ")
+
+    UpWords: set[str] = {
+        "arriba",
+        "subir",
+        "anterior",
+        "previo",
+        "previa",
+        "before",
+        "previous",
+        "up",
+        "cima",
+        "acima",
+        "voltar",
+        "back",
+    }
+
+    DownWords: set[str] = {
+        "abajo",
+        "bajar",
+        "siguiente",
+        "proximo",
+        "proxima",
+        "next",
+        "advance",
+        "down",
+        "abaixo",
+        "seguinte",
+    }
+
+    # "okey" no esta en las palabras de confirmacion compartidas
+    # (SpokenNumberParser.ConfirmationWords), asi que se suma aca sin tocar
+    # el comportamiento de los demas prompts.
+    OkeyWords: set[str] = {"okey", "okay", "ok"}
+
+    def __init__(
+        self,
+        Title: str = "DAV Sketch Orientation",
+        Message: str = "Elegí el plano del boceto (XY, XZ o YZ)",
+        Parent=None,
+    ) -> None:
+        super().__init__(Title, Message, Parent)
+        self._CurrentIndex = 0
+        self._Plane = self.PlaneKeys[self._CurrentIndex]
+        self.SetStatus(self._StatusText())
+        self.SetHeardText(self._Plane)
+
+    def ProcessPartialText(self, Text: str) -> None:
+        """Preview recognized text without acting on it."""
+        self.SetHeardText(Text)
+        self.SetStatus(self._StatusText())
+
+    def ProcessFinalText(self, Text: str) -> PromptResult:
+        """Handle up/down navigation and okey/cancel confirmation."""
+        self.SetHeardText(Text)
+        tokens = SpokenNumberParser.Tokenize(Text)
+        tokens_set = set(tokens)
+
+        if tokens_set & self.CancellationWords:
+            return self.Cancel()
+
+        if tokens_set & self.DownWords:
+            self._Step(1)
+            self._Result = PromptResult.Pending()
+            self.SetStatus(self._StatusText())
+            return self.GetResult()
+
+        if tokens_set & self.UpWords:
+            self._Step(-1)
+            self._Result = PromptResult.Pending()
+            self.SetStatus(self._StatusText())
+            return self.GetResult()
+
+        if tokens_set & self.OkeyWords or self._HasConfirmation(tokens):
+            return self.AcceptValue(self._Plane)
+
+        self.SetStatus("Decí arriba o abajo, y después okey o cancelar.")
+        return self.GetResult()
+
+    @property
+    def CancellationWords(self) -> set[str]:
+        """Return the shared cancellation words."""
+        return SpokenNumberParser.CancellationWords
+
+    def GetSelectedPlane(self) -> str:
+        """Return the currently highlighted plane key (XY, XZ or YZ)."""
+        return self._Plane
+
+    def _Step(self, Direction: int) -> None:
+        total = len(self.PlaneKeys)
+        self._CurrentIndex = (self._CurrentIndex + Direction) % total
+        self._Plane = self.PlaneKeys[self._CurrentIndex]
+        self.SetHeardText(self._Plane)
+
+    def _StatusText(self) -> str:
+        return (
+            f"Plano {self._Plane} ({self._CurrentIndex + 1}/{len(self.PlaneKeys)})"
+            " — decí arriba o abajo, okey para confirmar, cancelar para salir."
+        )


### PR DESCRIPTION
Reemplaza el diálogo nativo de FreeCAD (SketchOrientationDialog), que no es controlable por voz, por un selector DAV (PlaneSelectionInputPrompt).
El usuario recorre los ejes XY/XZ/YZ con "arriba"/"abajo" y confirma con "okey"/"cancelar".
El boceto se crea sobre el plano elegido usando el mismo placement que el comando nativo.
Se acota la gramática de Vosk (nuevo PlaneGrammarSwitcher) mientras el selector está abierto a solo arriba/abajo/okey/cancelar, para evitar falsos positivos (ej. "abajo" → "trabajo").
Sinónimos "nuevo boceto"/"crear boceto"/"boceto nuevo" en el TraduceTo del Sketcher.