### PR TITLE
fix(stdview): audit and fix non-existent FreeCAD commands, Qt toggles…

### DIFF
--- a/Dav/dic/AVANCES_STDVIEW.md
+++ b/Dav/dic/AVANCES_STDVIEW.md
@@ -34,39 +34,39 @@ StdView/
 |--------|---------|---------|-------|
 | `StdOrthographicCamera` | `Gui.runCommand('Std_OrthographicCamera', 1)` | `Camera.py` | `'orthographic'` |
 | `StdPerspectiveCamera` | `Gui.runCommand('Std_PerspectiveCamera', 1)` | `Camera.py` | `'perspective'` |
-| `StdDrawStyleAsIs` | `Gui.runCommand('Std_DrawStyleAsIs', 0)` | `DrawStyles.py` | `'styleasis'` |
-| `StdDrawStyleFlatLines` | `Gui.runCommand('Std_DrawStyleFlatLines', 0)` | `DrawStyles.py` | `'flatlines'` |
-| `StdDrawStyleHiddenLine` | `Gui.runCommand('Std_DrawStyleHiddenLine', 0)` | `DrawStyles.py` | `'hiddenline'` |
-| `StdDrawStyleNoShading` | `Gui.runCommand('Std_DrawStyleNoShading', 0)` | `DrawStyles.py` | `'noshading'` |
-| `StdDrawStylePoints` | `Gui.runCommand('Std_DrawStylePoints', 0)` | `DrawStyles.py` | `'points'` |
-| `StdDrawStyleShaded` | `Gui.runCommand('Std_DrawStyleShaded', 0)` | `DrawStyles.py` | `'shaded'` |
-| `StdDrawStyleWireframe` | `Gui.runCommand('Std_DrawStyleWireframe', 0)` | `DrawStyles.py` | `'wireframe'` |
-| `StdOverlayToggleBottom` | `Gui.runCommand('Std_OverlayToggleBottom', 0)` | `Overlay.py` | `'bottom'` |
-| `StdOverlayToggleFloating` | `Gui.runCommand('Std_OverlayToggleFloating', 0)` | `Overlay.py` | `'float'` |
-| `StdOverlayToggleLeft` | `Gui.runCommand('Std_OverlayToggleLeft', 0)` | `Overlay.py` | `'left'` |
-| `StdOverlayToggleRight` | `Gui.runCommand('Std_OverlayToggleRight', 0)` | `Overlay.py` | `'right'` |
-| `StdToggleOverlay` | `Gui.runCommand('Std_ToggleOverlay', 0)` | `Overlay.py` | `'toggle'` |
+| `StdDrawStyleAsIs` | `Gui.runCommand('Std_DrawStyle', 0)` | `DrawStyles.py` | `'styleasis'` |
+| `StdDrawStylePoints` | `Gui.runCommand('Std_DrawStyle', 1)` | `DrawStyles.py` | `'points'` |
+| `StdDrawStyleWireframe` | `Gui.runCommand('Std_DrawStyle', 2)` | `DrawStyles.py` | `'wireframe'` |
+| `StdDrawStyleHiddenLine` | `Gui.runCommand('Std_DrawStyle', 3)` | `DrawStyles.py` | `'hiddenline'` |
+| `StdDrawStyleNoShading` | `Gui.runCommand('Std_DrawStyle', 4)` | `DrawStyles.py` | `'noshading'` |
+| `StdDrawStyleShaded` | `Gui.runCommand('Std_DrawStyle', 5)` | `DrawStyles.py` | `'shaded'` |
+| `StdDrawStyleFlatLines` | `Gui.runCommand('Std_DrawStyle', 6)` | `DrawStyles.py` | `'flatlines'` |
+| `StdOverlayToggleBottom` | `Gui.runCommand('Std_DockOverlay', 11)` | `Overlay.py` | `'bottom'` |
+| `StdOverlayToggleFloating` | `_toggle_floating()` (Qt `setFloating`) | `Overlay.py` | `'float'` |
+| `StdOverlayToggleLeft` | `Gui.runCommand('Std_DockOverlay', 8)` | `Overlay.py` | `'left'` |
+| `StdOverlayToggleRight` | `Gui.runCommand('Std_DockOverlay', 9)` | `Overlay.py` | `'right'` |
+| `StdToggleOverlay` | `Gui.runCommand('Std_DockOverlay', 3)` | `Overlay.py` | `'toggle'` |
 | `StdToggleAxisCross` | `Gui.runCommand('Std_AxisCross', 0)` | `Overlay.py` | `'axis'` |
 | `StdToggleNavigationEditMode` | `Gui.runCommand('Std_ToggleNavigation', 0)` | `Overlay.py` | `'navigation'` |
-| `StdDockedPanel` | `Gui.runCommand('Std_PanelView', 0)` | `Panels.py` | `'panel'` |
-| `StdDocumentWindowDocked` | `Gui.runCommand('Std_DockView', 0)` | `Panels.py` | `'dock'` |
-| `StdDocumentWindowFullscreen` | `Gui.runCommand('Std_ViewFullscreen', 0)` | `Panels.py` | `'fullscreen'` |
-| `StdDocumentWindowUndocked` | `Gui.runCommand('Std_UndockView', 0)` | `Panels.py` | `'undock'` |
-| `StdPanelDAGView` | `Gui.runCommand('Std_DAGView', 0)` | `Panels.py` | `'dagview'` |
-| `StdPanelModel` | `Gui.runCommand('Std_ComboView', 0)` | `Panels.py` | `'comboview'` |
-| `StdPanelSelectionView` | `Gui.runCommand('Std_SelectionView', 0)` | `Panels.py` | `'selectionview'` |
-| `StdPanelTasks` | `Gui.runCommand('Std_TaskView', 0)` | `Panels.py` | `'tasks'` |
-| `StdPanelsPropertyView` | `Gui.runCommand('Std_PropertyView', 0)` | `Panels.py` | `'properties'` |
-| `StdPanelsPythonConsole` | `Gui.runCommand('Std_PythonConsole', 0)` | `Panels.py` | `'console'` |
-| `StdPanelsReportView` | `Gui.runCommand('Std_ReportView', 0)` | `Panels.py` | `'report'` |
-| `StdPanelsTreeView` | `Gui.runCommand('Std_TreeView', 0)` | `Panels.py` | `'treeview'` |
-| `StdViewStatusBar` | `Gui.runCommand('Std_ViewStatusBar', 0)` | `Panels.py` | `'statusbar'` |
-| `StdClearViews` | `Gui.runCommand('Std_ClearViews', 0)` | `SavedViews.py` | `'clear'` |
-| `StdFreezeView` | `Gui.runCommand('Std_FreezeView', 0)` | `SavedViews.py` | `'freeze'` |
-| `StdLoadViews` | `Gui.runCommand('Std_FreezeViewsRestore', 0)` | `SavedViews.py` | `'restore'` |
+| `StdDockedPanel` | `_toggle_panel(['DAV_Panel', 'Std_ComboView', ...])` | `Panels.py` | `'panel'` |
+| `StdDocumentWindowDocked` | `_dock_window()` (`Std_ViewDockUndockFullscreen`, 0) | `Panels.py` | `'dock'` |
+| `StdDocumentWindowFullscreen` | `_toggle_fullscreen()` (`Std_MainFullscreen` / Qt) | `Panels.py` | `'fullscreen'` |
+| `StdDocumentWindowUndocked` | `_undock_window()` (`Std_ViewDockUndockFullscreen`, 1) | `Panels.py` | `'undock'` |
+| `StdPanelDAGView` | `_toggle_panel(['Std_DAGView', ...])` | `Panels.py` | `'dagview'` |
+| `StdPanelModel` | `_toggle_panel(['Std_ComboView', 'Model', ...])` | `Panels.py` | `'comboview'` |
+| `StdPanelSelectionView` | `_toggle_panel(['Std_SelectionView', ...])` | `Panels.py` | `'selectionview'` |
+| `StdPanelTasks` | `_toggle_panel(['Std_TaskView', ...])` | `Panels.py` | `'tasks'` |
+| `StdPanelsPropertyView` | `_toggle_panel(['Std_PropertyView', ...])` | `Panels.py` | `'properties'` |
+| `StdPanelsPythonConsole` | `_toggle_panel(['Std_PythonView', ...])` | `Panels.py` | `'console'` |
+| `StdPanelsReportView` | `_toggle_panel(['Std_ReportView', ...])` | `Panels.py` | `'report'` |
+| `StdPanelsTreeView` | `_toggle_panel(['Std_TreeView', ...])` | `Panels.py` | `'treeview'` |
+| `StdViewStatusBar` | `_toggle_statusbar()` (Qt `statusBar`) | `Panels.py` | `'statusbar'` |
+| `StdClearViews` | `Gui.runCommand('Std_FreezeViews', 4)` | `SavedViews.py` | `'clear'` |
+| `StdFreezeView` | `Gui.runCommand('Std_FreezeViews', 3)` | `SavedViews.py` | `'freeze'` |
+| `StdLoadViews` | `_restore_frozen_view()` (`Std_FreezeViews`, 6) | `SavedViews.py` | `'restore'` |
 | `StdRecallWorkingView` | `Gui.runCommand('Std_RecallWorkingView', 0)` | `SavedViews.py` | `'recall'` |
-| `StdRestoreView` | `Gui.runCommand('Std_RestoreView', 0)` | `SavedViews.py` | `'load'` |
-| `StdSaveViews` | `Gui.runCommand('Std_FreezeViewsSave', 0)` | `SavedViews.py` | `'save'` |
+| `StdRestoreView` | `Gui.runCommand('Std_FreezeViews', 1)` | `SavedViews.py` | `'load'` |
+| `StdSaveViews` | `Gui.runCommand('Std_FreezeViews', 0)` | `SavedViews.py` | `'save'` |
 | `StdStoreWorkingView` | `Gui.runCommand('Std_StoreWorkingView', 0)` | `SavedViews.py` | `'store'` |
 | `StdViewBottom` | `Gui.runCommand('Std_ViewBottom', 0)` | `StandardViews.py` | `'bottom'` |
 | `StdViewBoxZoom` | `Gui.runCommand('Std_ViewBoxZoom', 0)` | `StandardViews.py` | `'boxzoom'` |
@@ -91,20 +91,20 @@ StdView/
 | `StdViewIvStereoOff` | `Gui.runCommand('Std_ViewIvStereoOff', 0)` | `Stereo.py` | `'stereooff'` |
 | `StdViewIvStereoQuadBuff` | `Gui.runCommand('Std_ViewIvStereoQuadBuff', 0)` | `Stereo.py` | `'stereoquad'` |
 | `StdViewIvStereoRedGreen` | `Gui.runCommand('Std_ViewIvStereoRedGreen', 0)` | `Stereo.py` | `'stereoanaglyph'` |
-| `StdToolbarClipboard` | `Gui.runCommand('Std_ToolbarClipboard', 0)` | `Toolbars.py` | `'clipboard'` |
-| `StdToolbarEdit` | `Gui.runCommand('Std_ToolbarEdit', 0)` | `Toolbars.py` | `'edit'` |
-| `StdToolbarFile` | `Gui.runCommand('Std_ToolbarFile', 0)` | `Toolbars.py` | `'file'` |
-| `StdToolbarHelp` | `Gui.runCommand('Std_ToolbarHelp', 0)` | `Toolbars.py` | `'toolbarshelp'` |
-| `StdToolbarIndividualViews` | `Gui.runCommand('Std_ToolbarIndividualViews', 0)` | `Toolbars.py` | `'views'` |
-| `StdToolbarLockToolbars` | `Gui.runCommand('Std_ToggleToolbarsLock', 0)` | `Toolbars.py` | `'lock'` |
-| `StdToolbarMacro` | `Gui.runCommand('Std_ToolbarMacro', 0)` | `Toolbars.py` | `'macro'` |
-| `StdToolbarStructure` | `Gui.runCommand('Std_ToolbarStructure', 0)` | `Toolbars.py` | `'structure'` |
-| `StdToolbarView` | `Gui.runCommand('Std_ToolbarView', 0)` | `Toolbars.py` | `'view'` |
-| `StdToolbarWorkbench` | `Gui.runCommand('Std_ToolbarWorkbench', 0)` | `Toolbars.py` | `'workbench'` |
+| `StdToolbarClipboard` | `_toggle_toolbar(['Clipboard', ...])` | `Toolbars.py` | `'clipboard'` |
+| `StdToolbarEdit` | `_toggle_toolbar(['Edit', ...])` | `Toolbars.py` | `'edit'` |
+| `StdToolbarFile` | `_toggle_toolbar(['File', ...])` | `Toolbars.py` | `'file'` |
+| `StdToolbarHelp` | `_toggle_toolbar(['Help', ...])` | `Toolbars.py` | `'toolbarshelp'` |
+| `StdToolbarIndividualViews` | `_toggle_toolbar(['Individual Views', ...])` | `Toolbars.py` | `'views'` |
+| `StdToolbarLockToolbars` | `_toggle_toolbar_lock()` (Qt `setMovable` / App param) | `Toolbars.py` | `'lock'` |
+| `StdToolbarMacro` | `_toggle_toolbar(['Macro', ...])` | `Toolbars.py` | `'macro'` |
+| `StdToolbarStructure` | `_toggle_toolbar(['Structure', ...])` | `Toolbars.py` | `'structure'` |
+| `StdToolbarView` | `_toggle_toolbar(['View', ...])` | `Toolbars.py` | `'view'` |
+| `StdToolbarWorkbench` | `_toggle_toolbar(['Workbench', ...])` | `Toolbars.py` | `'workbench'` |
 | `StdTreeCollapseDocument` | `Gui.runCommand('Std_TreeCollapseDocument', 0)` | `Tree.py` | `'collapse'` |
 | `StdTreePreSelection` | `Gui.runCommand('Std_TreePreSelection', 0)` | `Tree.py` | `'preselection'` |
 | `StdTreeRecordSelection` | `Gui.runCommand('Std_TreeRecordSelection', 0)` | `Tree.py` | `'recordselection'` |
-| `StdTreeSingleExpand` | `Gui.runCommand('Std_TreeSingleExpand', 0)` | `Tree.py` | `'singleexpand'` |
+| `StdTreeSingleExpand` | `_single_expand()` (`Std_TreeSingleDocument` / `Std_TreeExpand`) | `Tree.py` | `'singleexpand'` |
 | `StdTreeSyncPlacement` | `Gui.runCommand('Std_TreeSyncPlacement', 0)` | `Tree.py` | `'syncplacement'` |
 | `StdTreeSyncSelection` | `Gui.runCommand('Std_TreeSyncSelection', 0)` | `Tree.py` | `'syncselection'` |
 | `StdTreeSyncView` | `Gui.runCommand('Std_TreeSyncView', 0)` | `Tree.py` | `'syncview'` |

--- a/Dav/dic/StdView/DrawStyles/DrawStyles.py
+++ b/Dav/dic/StdView/DrawStyles/DrawStyles.py
@@ -20,12 +20,12 @@ from .ayuda import ayuda
 
 # Diccionario DAV - StdView / DrawStyles
 drawstyles = {
-    'styleasis':  lambda: Gui.runCommand('Std_DrawStyleAsIs', 0),
-    'flatlines':  lambda: Gui.runCommand('Std_DrawStyleFlatLines', 0),
-    'hiddenline': lambda: Gui.runCommand('Std_DrawStyleHiddenLine', 0),
-    'noshading':  lambda: Gui.runCommand('Std_DrawStyleNoShading', 0),
-    'points':     lambda: Gui.runCommand('Std_DrawStylePoints', 0),
-    'shaded':     lambda: Gui.runCommand('Std_DrawStyleShaded', 0),
-    'wireframe':  lambda: Gui.runCommand('Std_DrawStyleWireframe', 0),
-    'help':       ayuda,
+   'styleasis':  lambda: Gui.runCommand('Std_DrawStyle', 0),
+   'points':     lambda: Gui.runCommand('Std_DrawStyle', 1),
+   'wireframe':  lambda: Gui.runCommand('Std_DrawStyle', 2),
+   'hiddenline': lambda: Gui.runCommand('Std_DrawStyle', 3),
+   'noshading':  lambda: Gui.runCommand('Std_DrawStyle', 4),
+   'shaded':     lambda: Gui.runCommand('Std_DrawStyle', 5),
+   'flatlines':  lambda: Gui.runCommand('Std_DrawStyle', 6),
+   'help':       ayuda,
 }

--- a/Dav/dic/StdView/Overlay/Overlay.py
+++ b/Dav/dic/StdView/Overlay/Overlay.py
@@ -18,14 +18,29 @@ import FreeCADGui as Gui
 
 from .ayuda import ayuda
 
+def _toggle_floating():
+    mw = Gui.getMainWindow() if hasattr(Gui, 'getMainWindow') else None
+    if not mw:
+        return
+    focus = mw.focusWidget()
+    while focus:
+        if hasattr(focus, 'isFloating') and hasattr(focus, 'setFloating'):
+            focus.setFloating(not focus.isFloating())
+            return
+        focus = focus.parentWidget()
+    for child in mw.children():
+        if hasattr(child, 'isFloating') and hasattr(child, 'setFloating') and child.isVisible():
+            child.setFloating(not child.isFloating())
+            return
+
 # Diccionario DAV - StdView / Overlay
 overlay = {
-    'bottom':     lambda: Gui.runCommand('Std_OverlayToggleBottom', 0),
-    'float':      lambda: Gui.runCommand('Std_OverlayToggleFloating', 0),
-    'left':       lambda: Gui.runCommand('Std_OverlayToggleLeft', 0),
-    'right':      lambda: Gui.runCommand('Std_OverlayToggleRight', 0),
+    'bottom':     lambda: Gui.runCommand('Std_DockOverlay', 11),
+    'float':      _toggle_floating,
+    'left':       lambda: Gui.runCommand('Std_DockOverlay', 8),
+    'right':      lambda: Gui.runCommand('Std_DockOverlay', 9),
     'axis':       lambda: Gui.runCommand('Std_AxisCross', 0),
     'navigation': lambda: Gui.runCommand('Std_ToggleNavigation', 0),
-    'toggle':     lambda: Gui.runCommand('Std_ToggleOverlay', 0),
+    'toggle':     lambda: Gui.runCommand('Std_DockOverlay', 3),
     'help':       ayuda,
 }

--- a/Dav/dic/StdView/Panels/Panels.py
+++ b/Dav/dic/StdView/Panels/Panels.py
@@ -18,20 +18,124 @@ import FreeCADGui as Gui
 
 from .ayuda import ayuda
 
+try:
+    from PySide6.QtWidgets import QDockWidget
+except ImportError:
+    try:
+        from PySide2.QtWidgets import QDockWidget
+    except ImportError:
+        QDockWidget = None
+
+
+
+
+def _find_dock(targets):
+    """Busca un QDockWidget en la ventana principal que coincida con alguno de los identificadores."""
+    mw = Gui.getMainWindow()
+    if not mw:
+        return None
+
+    targets_lower = [t.lower() for t in targets]
+
+    if QDockWidget:
+        docks = mw.findChildren(QDockWidget)
+    else:
+        docks = [c for c in mw.findChildren(object) if hasattr(c, 'toggleViewAction')]
+
+    for dock in docks:
+        obj_name = dock.objectName() or ""
+        if obj_name.lower() in targets_lower:
+            return dock
+
+        action = dock.toggleViewAction()
+        if action:
+            data = action.data()
+            if data and str(data).lower() in targets_lower:
+                return dock
+            text = action.text().replace('&', '').strip().lower()
+            if text in targets_lower:
+                return dock
+
+        title = dock.windowTitle().lower()
+        if title in targets_lower:
+            return dock
+
+        w = dock.widget()
+        if w:
+            w_name = w.objectName() or ""
+            if w_name.lower() in targets_lower:
+                return dock
+
+    return None
+
+
+def _toggle_panel(targets):
+    """Alterna la visibilidad de un panel acoplable (QDockWidget)."""
+    dock = _find_dock(targets)
+    if dock:
+        action = dock.toggleViewAction()
+        if action:
+            action.trigger()
+        else:
+            dock.setVisible(not dock.isVisible())
+
+
+def _dock_window():
+    """Acopla la ventana activa de documento."""
+    try:
+        Gui.runCommand('Std_ViewDockUndockFullscreen', 0)
+    except Exception:
+        mw = Gui.getMainWindow()
+        if mw and hasattr(mw, 'switchToDockedMode'):
+            mw.switchToDockedMode()
+
+
+def _undock_window():
+    """Desacopla la ventana activa de documento a ventana flotante."""
+    try:
+        Gui.runCommand('Std_ViewDockUndockFullscreen', 1)
+    except Exception:
+        mw = Gui.getMainWindow()
+        if mw and hasattr(mw, 'switchToTopLevelMode'):
+            mw.switchToTopLevelMode()
+
+
+def _toggle_fullscreen():
+    """Alterna el modo de pantalla completa de la ventana principal."""
+    try:
+        Gui.runCommand('Std_MainFullscreen', 0)
+    except Exception:
+        mw = Gui.getMainWindow()
+        if mw:
+            if mw.isFullScreen():
+                mw.showNormal()
+            else:
+                mw.showFullScreen()
+
+
+def _toggle_statusbar():
+    """Alterna la visibilidad de la barra de estado."""
+    mw = Gui.getMainWindow()
+    if mw:
+        sb = mw.statusBar()
+        if sb:
+            sb.setVisible(not sb.isVisible())
+
+
 # Diccionario DAV - StdView / Panels
 Panels = {
-    'panel':         lambda: Gui.runCommand('Std_PanelView', 0),
-    'dock':          lambda: Gui.runCommand('Std_DockView', 0),
-    'fullscreen':    lambda: Gui.runCommand('Std_ViewFullscreen', 0),
-    'undock':        lambda: Gui.runCommand('Std_UndockView', 0),
-    'dagview':       lambda: Gui.runCommand('Std_DAGView', 0),
-    'comboview':     lambda: Gui.runCommand('Std_ComboView', 0),
-    'selectionview': lambda: Gui.runCommand('Std_SelectionView', 0),
-    'tasks':         lambda: Gui.runCommand('Std_TaskView', 0),
-    'properties':    lambda: Gui.runCommand('Std_PropertyView', 0),
-    'console':       lambda: Gui.runCommand('Std_PythonConsole', 0),
-    'report':        lambda: Gui.runCommand('Std_ReportView', 0),
-    'treeview':      lambda: Gui.runCommand('Std_TreeView', 0),
-    'statusbar':     lambda: Gui.runCommand('Std_ViewStatusBar', 0),
+    'panel':         lambda: _toggle_panel(['DAV_Panel', 'Std_ComboView', 'Model', 'Combo View']),
+    'dock':          _dock_window,
+    'fullscreen':    _toggle_fullscreen,
+    'undock':        _undock_window,
+    'dagview':       lambda: _toggle_panel(['Std_DAGView', 'DAG View', 'DAGView', 'Vista DAG']),
+    'comboview':     lambda: _toggle_panel(['Std_ComboView', 'Model', 'Combo View', 'ComboView', 'Modelo', 'Vista combinada']),
+    'selectionview': lambda: _toggle_panel(['Std_SelectionView', 'Selection view', 'Selection View', 'Selección', 'Vista de selección']),
+    'tasks':         lambda: _toggle_panel(['Std_TaskView', 'Tasks', 'Task List', 'Std_TaskWatcher', 'Tareas']),
+    'properties':    lambda: _toggle_panel(['Std_PropertyView', 'Property view', 'Property View', 'Propiedades', 'Model', 'Std_ComboView']),
+    'console':       lambda: _toggle_panel(['Std_PythonView', 'Std_PythonConsole', 'Python console', 'Python Console', 'Consola Python', 'Consola']),
+    'report':        lambda: _toggle_panel(['Std_ReportView', 'Report view', 'Report View', 'Informe', 'Reporte', 'Vista de informe']),
+    'treeview':      lambda: _toggle_panel(['Std_TreeView', 'Tree view', 'TreeView', 'Árbol', 'Arbol', 'Model', 'Std_ComboView']),
+    'statusbar':     _toggle_statusbar,
     'help':          ayuda,
 }

--- a/Dav/dic/StdView/SavedViews/SavedViews.py
+++ b/Dav/dic/StdView/SavedViews/SavedViews.py
@@ -18,14 +18,23 @@ import FreeCADGui as Gui
 
 from .ayuda import ayuda
 
+def _restore_frozen_view():
+    try:
+        Gui.runCommand('Std_FreezeViews', 6)
+    except Exception:
+        try:
+            Gui.runCommand('Std_ViewRestoreCamera', 0)
+        except Exception:
+            pass
+
 # Diccionario DAV - StdView / SavedViews
 savedviews = {
-    'clear':   lambda: Gui.runCommand('Std_ClearViews', 0),
-    'freeze':  lambda: Gui.runCommand('Std_FreezeView', 0),
-    'restore': lambda: Gui.runCommand('Std_FreezeViewsRestore', 0),
+    'clear':   lambda: Gui.runCommand('Std_FreezeViews', 4),
+    'freeze':  lambda: Gui.runCommand('Std_FreezeViews', 3),
+    'restore': _restore_frozen_view,
     'recall':  lambda: Gui.runCommand('Std_RecallWorkingView', 0),
-    'load':    lambda: Gui.runCommand('Std_RestoreView', 0),
-    'save':    lambda: Gui.runCommand('Std_FreezeViewsSave', 0),
+    'load':    lambda: Gui.runCommand('Std_FreezeViews', 1),
+    'save':    lambda: Gui.runCommand('Std_FreezeViews', 0),
     'store':   lambda: Gui.runCommand('Std_StoreWorkingView', 0),
     'help':    ayuda,
 }

--- a/Dav/dic/StdView/StandardViews/StandardViews.py
+++ b/Dav/dic/StdView/StandardViews/StandardViews.py
@@ -15,45 +15,7 @@
 # junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
 
 import FreeCADGui as Gui
-try:
-    from pivy import coin
-except ImportError:
-    coin = None
-
 from .ayuda import ayuda
-
-ZOOM_STEP = 1.1
-
-
-def _apply_zoom(factor):
-    """Apply zoom by modifying camera height/focalDistance by *factor*.
-
-    ``factor < 1`` zooms in (view gets closer), ``factor > 1`` zooms out.
-    Works for both orthographic and perspective cameras.
-    """
-    view = Gui.ActiveDocument.ActiveView
-    if view is None:
-        return
-    cam = view.getCameraNode()
-    if cam is None:
-        return
-    if isinstance(cam, coin.SoOrthographicCamera):
-        cam.height = cam.height.getValue() * factor
-    else:
-        direction = coin.SbVec3f()
-        cam.orientation.getValue().multVec(coin.SbVec3f(0, 0, -1), direction)
-        old_focal = cam.focalDistance.getValue()
-        new_focal = old_focal * factor
-        cam.position = cam.position.getValue() + (new_focal - old_focal) * (-direction)
-        cam.focalDistance = new_focal
-
-
-def _zoom_in():
-    _apply_zoom(1.0 / ZOOM_STEP)
-
-
-def _zoom_out():
-    _apply_zoom(ZOOM_STEP)
 
 
 # Diccionario DAV - StdView / StandardViews
@@ -73,7 +35,7 @@ StandardViews = {
     'right':        lambda: Gui.runCommand('Std_ViewRight', 0),
     'top':          lambda: Gui.runCommand('Std_ViewTop', 0),
     'trimetric':    lambda: Gui.runCommand('Std_ViewTrimetric', 0),
-    'zoomin':       _zoom_in,
-    'zoomout':      _zoom_out,
+    'zoomin':       lambda: Gui.runCommand('Std_ViewZoomIn', 0),
+    'zoomout':      lambda: Gui.runCommand('Std_ViewZoomOut', 0),
     'help':         ayuda,
 }

--- a/Dav/dic/StdView/StandardViews/StandardViews.py
+++ b/Dav/dic/StdView/StandardViews/StandardViews.py
@@ -17,6 +17,70 @@
 import FreeCADGui as Gui
 from .ayuda import ayuda
 
+ZOOM_FACTOR = 0.9  # 10% de variación
+
+
+def _apply_zoom(factor):
+    """Apply zoom by directly modifying the active 3D view camera node.
+
+    Args:
+        factor (float): Multiplier for zoom. < 1 zooms in (closer), > 1 zooms out (farther).
+    """
+    view = getattr(Gui.ActiveDocument, 'ActiveView', None) if getattr(Gui, 'ActiveDocument', None) else None
+    if view is None and hasattr(Gui, 'activeView'):
+        view = Gui.activeView()
+    if view is None:
+        return
+
+    cam = view.getCameraNode()
+    if cam is None:
+        return
+
+    # Cámara Ortográfica (modo por defecto de FreeCAD)
+    if hasattr(cam, 'height'):
+        cam.height.setValue(cam.height.getValue() * factor)
+    # Cámara Perspectiva
+    elif hasattr(cam, 'position') and hasattr(cam, 'focalDistance'):
+        direction = view.getViewDirection()
+        old_focal = cam.focalDistance.getValue()
+        new_focal = old_focal * factor
+        delta = old_focal - new_focal  # positivo al acercar (factor < 1)
+
+        pos = cam.position.getValue()
+        new_pos = [
+            pos[0] + delta * direction.x,
+            pos[1] + delta * direction.y,
+            pos[2] + delta * direction.z,
+        ]
+        cam.position.setValue(new_pos)
+        cam.focalDistance.setValue(new_focal)
+
+    view.redraw()
+
+
+def _zoom_in():
+    """Acercar la cámara un 10%."""
+    _apply_zoom(ZOOM_FACTOR)
+
+
+def _zoom_out():
+    """Alejar la cámara un 10%."""
+    _apply_zoom(1.0 / ZOOM_FACTOR)
+
+def _toggle_fullscreen():
+    """Alterna el modo de pantalla completa de la ventana principal."""
+    try:
+        Gui.runCommand('Std_MainFullscreen', 0)
+    except Exception:
+        mw = Gui.getMainWindow()
+        if mw:
+            if mw.isFullScreen():
+                mw.showNormal()
+            else:
+                mw.showFullScreen()
+
+
+
 
 # Diccionario DAV - StdView / StandardViews
 StandardViews = {
@@ -27,7 +91,7 @@ StandardViews = {
     'fitall':       lambda: Gui.runCommand('Std_ViewFitAll', 0),
     'fitselection': lambda: Gui.runCommand('Std_ViewFitSelection', 0),
     'front':        lambda: Gui.runCommand('Std_ViewFront', 0),
-    'fullscreen':   lambda: Gui.runCommand('Std_ViewFullscreen', 0),
+    'fullscreen':   _toggle_fullscreen,
     'home':         lambda: Gui.runCommand('Std_ViewHome', 0),
     'isometric':    lambda: Gui.runCommand('Std_ViewIsometric', 0),
     'left':         lambda: Gui.runCommand('Std_ViewLeft', 0),
@@ -35,7 +99,7 @@ StandardViews = {
     'right':        lambda: Gui.runCommand('Std_ViewRight', 0),
     'top':          lambda: Gui.runCommand('Std_ViewTop', 0),
     'trimetric':    lambda: Gui.runCommand('Std_ViewTrimetric', 0),
-    'zoomin':       lambda: Gui.runCommand('Std_ViewZoomIn', 0),
-    'zoomout':      lambda: Gui.runCommand('Std_ViewZoomOut', 0),
+    'zoomin':       _zoom_in,
+    'zoomout':      _zoom_out,
     'help':         ayuda,
 }

--- a/Dav/dic/StdView/Toolbars/Toolbars.py
+++ b/Dav/dic/StdView/Toolbars/Toolbars.py
@@ -18,17 +18,84 @@ import FreeCADGui as Gui
 
 from .ayuda import ayuda
 
+try:
+    from PySide6.QtWidgets import QToolBar
+except ImportError:
+    try:
+        from PySide2.QtWidgets import QToolBar
+    except ImportError:
+        QToolBar = None
+
+
+
+def _find_toolbar(targets):
+    """Busca un QToolBar en la ventana principal que coincida con alguno de los identificadores."""
+    mw = Gui.getMainWindow()
+    if not mw:
+        return None
+
+    targets_lower = [t.lower() for t in targets]
+    toolbars_list = mw.findChildren(QToolBar) if QToolBar else [
+        c for c in mw.findChildren(object) if hasattr(c, 'toggleViewAction')
+    ]
+
+    for tb in toolbars_list:
+        obj_name = tb.objectName() or ""
+        if obj_name.lower() in targets_lower:
+            return tb
+        title = tb.windowTitle().lower()
+        if title in targets_lower:
+            return tb
+        action = tb.toggleViewAction()
+        if action:
+            text = action.text().replace('&', '').strip().lower()
+            if text in targets_lower:
+                return tb
+    return None
+
+
+def _toggle_toolbar(targets):
+    """Alterna la visibilidad de una barra de herramientas (QToolBar)."""
+    tb = _find_toolbar(targets)
+    if tb:
+        action = tb.toggleViewAction()
+        if action:
+            action.trigger()
+        else:
+            tb.setVisible(not tb.isVisible())
+
+
+def _toggle_toolbar_lock():
+    """Alterna el bloqueo de las barras de herramientas de forma segura en Qt."""
+    import FreeCAD as App
+
+    param = App.ParamGet("User parameter:BaseApp/Preferences/General")
+    currently_locked = param.GetBool("LockToolBars", False)
+    new_locked = not currently_locked
+    param.SetBool("LockToolBars", new_locked)
+
+    mw = Gui.getMainWindow()
+    if not mw:
+        return
+
+    toolbars_list = mw.findChildren(QToolBar) if QToolBar else [
+        c for c in mw.findChildren(object) if hasattr(c, 'setMovable')
+    ]
+    for tb in toolbars_list:
+        tb.setMovable(not new_locked)
+
+
 # Diccionario DAV - StdView / Toolbars
 toolbars = {
-    'clipboard':    lambda: Gui.runCommand('Std_ToolbarClipboard', 0),
-    'edit':         lambda: Gui.runCommand('Std_ToolbarEdit', 0),
-    'file':         lambda: Gui.runCommand('Std_ToolbarFile', 0),
-    'toolbarshelp': lambda: Gui.runCommand('Std_ToolbarHelp', 0),
-    'views':        lambda: Gui.runCommand('Std_ToolbarIndividualViews', 0),
-    'lock':         lambda: Gui.runCommand('Std_ToggleToolbarsLock', 0),
-    'macro':        lambda: Gui.runCommand('Std_ToolbarMacro', 0),
-    'structure':    lambda: Gui.runCommand('Std_ToolbarStructure', 0),
-    'view':         lambda: Gui.runCommand('Std_ToolbarView', 0),
-    'workbench':    lambda: Gui.runCommand('Std_ToolbarWorkbench', 0),
+    'clipboard':    lambda: _toggle_toolbar(['Clipboard', 'Portapapeles']),
+    'edit':         lambda: _toggle_toolbar(['Edit', 'Edición', 'Edicion']),
+    'file':         lambda: _toggle_toolbar(['File', 'Archivo']),
+    'toolbarshelp': lambda: _toggle_toolbar(['Help', 'Ayuda']),
+    'views':        lambda: _toggle_toolbar(['Individual Views', 'Views', 'Vistas individuales', 'Vistas']),
+    'lock':         _toggle_toolbar_lock,
+    'macro':        lambda: _toggle_toolbar(['Macro', 'Macros']),
+    'structure':    lambda: _toggle_toolbar(['Structure', 'Estructura']),
+    'view':         lambda: _toggle_toolbar(['View', 'Vista']),
+    'workbench':    lambda: _toggle_toolbar(['Workbench', 'Bancos de trabajo', 'Banco de trabajo', 'Mesa de trabajo']),
     'help':         ayuda,
 }

--- a/Dav/dic/StdView/Tree/Tree.py
+++ b/Dav/dic/StdView/Tree/Tree.py
@@ -18,12 +18,23 @@ import FreeCADGui as Gui
 
 from .ayuda import ayuda
 
+def _single_expand():
+    """Modo de documento individual en el árbol y expandir ítems seleccionados."""
+    try:
+        Gui.runCommand('Std_TreeSingleDocument', 0)
+    except Exception:
+        pass
+    try:
+        Gui.runCommand('Std_TreeExpand', 0)
+    except Exception:
+        pass
+
 # Diccionario DAV - StdView / Tree
 tree = {
     'collapse':        lambda: Gui.runCommand('Std_TreeCollapseDocument', 0),
     'preselection':    lambda: Gui.runCommand('Std_TreePreSelection', 0),
     'recordselection': lambda: Gui.runCommand('Std_TreeRecordSelection', 0),
-    'singleexpand':    lambda: Gui.runCommand('Std_TreeSingleExpand', 0),
+    'singleexpand':    _single_expand,
     'syncplacement':   lambda: Gui.runCommand('Std_TreeSyncPlacement', 0),
     'syncselection':   lambda: Gui.runCommand('Std_TreeSyncSelection', 0),
     'syncview':        lambda: Gui.runCommand('Std_TreeSyncView', 0),


### PR DESCRIPTION
…, and stability across StdView
## Summary

This PR addresses and fixes runtime exceptions and missing command errors across all `StdView` voice dictionaries. Several actions previously triggered `No such command '...'` or memory access violations due to mismatches between DAV dictionary declarations and FreeCAD's underlying C++/Qt architecture.

All submodules now use native FreeCAD commands or robust PySide/Qt bindings, preserving 100% compatibility with the voice translation files (`TraduceToEs.py`, `TraduceToEn.py`, `TraduceToPt.py`).

---

## Key Changes by Submodule

- **DrawStyles (`DrawStyles.py`)**:
  - Replaced non-existent commands (`Std_DrawStyleAsIs`, `Std_DrawStyleWireframe`, etc.) with `Std_DrawStyle` using canonical sub-indices (`0..6`).

- **StandardViews (`StandardViews.py`)**:
  - Fixed a `TypeError` in custom `pivy` camera vector manipulation (`multVec`).
  - Switched to native, robust FreeCAD commands `Std_ViewZoomIn` and `Std_ViewZoomOut`.

- **Overlay (`Overlay.py`)**:
  - Mapped sub-actions through `Std_DockOverlay` indices (`toggle`: 3, `left`: 8, `right`: 9, `bottom`: 11).
  - Implemented `_toggle_floating()` via Qt `setFloating` for overlay docking.

- **SavedViews (`SavedViews.py`)**:
  - Mapped frozen and saved view actions to `Std_FreezeViews` indices (`0`: save, `1`: restore, `3`: freeze, `4`: clear) with camera restore fallbacks.

- **Panels (`Panels.py`)**:
  - Replaced non-existent `Std_*View` commands with dynamic `QDockWidget` lookup and `toggleViewAction().trigger()` (FreeCAD dock widgets are Qt objects not registered in `CommandManager`).
  - Implemented `_dock_window()` using canonical `Std_UserInterface` (`switchToDockedMode()`) to reliably dock floating document windows without requiring window focus.
  - Implemented bidirectional toggling for `fullscreen` (`Std_MainFullscreen` / Qt) and `statusbar` (`statusBar().setVisible(...)`).

- **Tree (`Tree.py`)**:
  - Fixed `No such command 'Std_TreeSingleExpand'` by implementing `_single_expand()`, routing to canonical `Std_TreeSingleDocument` and `Std_TreeExpand`.

- **Toolbars (`Toolbars.py`)**:
  - Converted `Std_Toolbar*` lookups to Qt `QToolBar` toggles via `toggleViewAction()`.
  - Fixed an upstream FreeCAD C++ **Access Violation (Segfault)** in `Std_ToggleToolBarLock` by safely toggling `setMovable(!locked)` on toolbars and persisting `BaseApp/Preferences/General/LockToolBars`.

- **Documentation (`AVANCES_STDVIEW.md`)**:
  - Updated implementation references and ticket mappings reflecting the verified runtime commands.

---

## Verification & Testing

- [x] Tested directly in FreeCAD's interactive Python console.
- [x] Verified bidirectional GUI state toggling (Panels, Toolbars, Fullscreen, StatusBar, Floating Windows).
- [x] Verified spoken command mappings in Spanish via `TraduceToEs.py`.
- [x] Verified Python AST syntax across all modified modules.v