### PR TITLE
docs: guia de desarrollo del proyecto DAV en Dav/docs

### DIFF
--- a/Dav/docs/desarrollo/agregar-comando.md
+++ b/Dav/docs/desarrollo/agregar-comando.md
@@ -1,0 +1,120 @@
+# Agregar un comando por voz
+
+El objetivo es que al decir una **frase hablada** se ejecute una **acción** de
+FreeCAD. Eso se logra tocando el **árbol de comandos** (`Dav/dic/`), sin tocar
+el motor (`Browser`).
+
+Cada carpeta de `Dav/dic/` es un **nivel de contexto** y tiene:
+
+1. **Un diccionario maestro** (`<nombre>.py`) — claves internas → callables.
+2. **Traducciones por idioma** (`TraduceToEs.py`, `TraduceToEn.py`,
+   `TraduceToPT.py`) — frases habladas → los mismos callables.
+
+## Paso a paso
+
+### 1. Ubicá la carpeta del contexto
+
+Por ejemplo, los comandos del workbench Sketcher viven en
+`Dav/dic/Workbench/Sketcher/`. Si el comando corresponde a un submenú, va en su
+carpeta hija (ej. `Sketcher/point/point.py`, `Sketcher/Geometry/geometry.py`).
+
+### 2. Agregá la clave interna al diccionario maestro
+
+Dentro del dict maestro (ej. `sketcher.py`), agregá la clave y su callable:
+
+```python
+sketcher = {}
+sketcher.update({
+    'new': _new_sketch,     # función propia que crea el boceto
+    'edit': lambda: Gui.runCommand('Sketcher_EditSketch', 0),
+    # ...
+})
+```
+
+> Si la acción es un comando nativo de FreeCAD que **no** abre un diálogo
+> controlable por voz, un `lambda: Gui.runCommand('Comando_De_FreeCAD', 0)`
+> alcanza. Si el comando nativo abre un diálogo propio (como el selector de
+> plano de `Sketcher_NewSketch`), hay que reemplazarlo por una acción propia de
+> DAV con un prompt controlable por voz (ver el ejemplo más abajo).
+
+### 3. Agregá las frases habladas en los `TraduceTo*.py`
+
+En el `TraduceToEs.py` del contexto, mapeá la/s frase/s a la clave:
+
+```python
+from .sketcher import sketcher
+
+TraduceToEs = {
+    "nuevo": sketcher["new"],
+    "nuevo croquis": sketcher["new"],
+    "crear croquis": sketcher["new"],
+    # ...
+}
+```
+
+> Sumar sinónimos es **solo** editar estos diccionarios: no hay que tocar el
+> motor. El `DictionaryLoader` normaliza acentos al comparar, así que las
+> variantes con/sin tilde son opcionales pero inofensivas.
+
+### 4. (Opcional) Actualizá el `ayuda.py` de la carpeta
+
+Muchos contextos tienen un `ayuda.py` que imprime los comandos disponibles.
+Agregá la línea del comando nuevo para que la ayuda sea consistente.
+
+### 5. Probalo
+
+Comprobá que la frase navega y ejecuta la acción (ver
+[probando.md](probando.md)). Probá en los **tres idiomas** si agregaste frases
+en los tres `TraduceTo`.
+
+---
+
+## Ejemplo real: el selector de plano por voz al crear un boceto
+
+Contexto: FreeCAD abre un diálogo nativo (`Sketcher_NewSketch`) que **no es
+controlable por voz**. La solución fue una acción propia de DAV que muestra un
+prompt navegable por voz.
+
+**Archivos tocados** (referencia):
+
+- `Dav/scr/.../InputPrompts/PlaneSelectionInputPrompt.py` — la ventana de
+  selección: recorre `XY` / `XZ` / `YZ` con `arriba`/`abajo` y confirma con
+  `okey`/`cancelar` (heredando `BaseInputPrompt`).
+- `Dav/dic/Workbench/Sketcher/new_sketch/new_sketch.py` — la acción: muestra el
+  prompt, toma el plano elegido y crea el `Sketcher::SketchObject` con el
+  mismo placement que el comando nativo.
+- `Dav/scr/.../InputPrompts/PlaneGrammarSwitcher.py` — acota la gramática de
+  Vosk mientras el prompt está abierto a solo `arriba/abajo/okey/cancelar`,
+  para que no confunda "abajo" con "trabajo".
+- `Dav/dic/Workbench/Sketcher/sketcher.py` — `'new'` ahora apunta a
+  `_new_sketch` en lugar de `Gui.runCommand('Sketcher_NewSketch', 0)`.
+- `Dav/dic/Workbench/Sketcher/Geometry/geometry.py` — idem para el subcontexto
+  de geometría.
+- `Dav/dic/Workbench/Sketcher/TraduceToEs.py` — sinónimos nuevos
+  `nuevo boceto` / `crear boceto` / `boceto nuevo`.
+
+**Puntos a copiar de este ejemplo**:
+
+- Si el comando abre un diálogo nativo, **reemplazalo** por un prompt DAV
+  (heredá `BaseInputPrompt` y usá `PromptVoiceRouter`).
+- Si el prompt necesita que Vosk escuche solo un conjunto chico de palabras,
+  usá un "grammar switcher" (patrón `NumericGrammarSwitcher`) y restamelo
+  al cerrar.
+- Avisá en la GUI (con `print`) el resultado de la acción para que aparezca en
+  el historial del panel.
+
+---
+
+## Reglas para no romper nada
+
+- **Subcontextos anidados**: `explorer.update({'file': file})`, nunca
+  `explorer.update(file)`. Ver [convenciones](convenciones.md) y
+  `pendientes-dav.md` §4.
+- Los `TraduceTo*.py` deben importar el dict maestro y enlazar
+  **por objeto/clave**, no duplicar callables.
+- Mantené el **cabezal obligatorio** en cada archivo nuevo.
+- No toques `browser.py` para sumar un comando: el comando va en el diccionario.
+
+---
+
+Siguiente: [Cómo probar y validar](probando.md)

--- a/Dav/docs/desarrollo/convenciones.md
+++ b/Dav/docs/desarrollo/convenciones.md
@@ -1,0 +1,98 @@
+# Convenciones de código
+
+Estas son las convenciones del proyecto DAV. Aplican a **todo el código propio**
+(el que vive en `Dav/`). Los archivos preexistentes de FreeCAD conservan sus
+propias reglas (y su cabezal original).
+
+> Fuente principal: `CLAUDE.md` del repo.
+
+## Nomenclatura
+
+| Tipo | Convención | Ejemplo |
+|---|---|---|
+| Clases | `PascalCase` | `DavAgent`, `VoskModel` |
+| Atributos / Propiedades | `PascalCase` | `LineColor`, `ShapeColor` |
+| Funciones / Métodos | `camelCase` (minúscula inicial) | `addObject()`, `recompute()` |
+| Uso interno | `_guiónBajo` | `_internalMethod` |
+
+## Organización de archivos
+
+- **Una clase = un archivo**
+- **Un diccionario = un archivo**
+- El nombre del archivo es igual al nombre de la clase (`DavAgent.py`)
+
+## Cabezal obligatorio (todos los archivos propios)
+
+Cada archivo propio DAV debe empezar con este cabezal de licencia:
+
+```python
+# Copyright (C) 2026 El Equipo del Proyecto DAV
+# Universidad Autónoma de Entre Ríos (UADER)
+# Bajo la dirección de Guillermo Gerard y Gallo Fabricio David
+#
+# Este programa es software libre: usted puede redistribuirlo y/o modificarlo
+# bajo los términos de la Licencia Pública General GNU tal como fue publicada
+# por la Fundación para el Software Libre, en la versión 3 de la Licencia.
+#
+# Este programa se distribuye con la esperanza de que sea útil,
+# pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+# MERCANTIBILIDAD o APTITUD PARA UN PROPÓSITO PARTICULAR. Consulte la
+# Licencia Pública General GNU para más detalles.
+#
+# Deberías haber recibido una copia de la Licencia Pública General GNU
+# junto con este programa. Si no es así, consulte <http://www.gnu.org/licenses/>.
+```
+
+> Los archivos de FreeCAD preexistentes **conservan su cabezal original**
+> (LGPL-2.1-or-later). No los reemplaces.
+
+## Docstrings
+
+- Toda **clase y método público** debe tener un docstring en **inglés**.
+- Formato: primera línea corta (resumen), línea en blanco, luego secciones
+  `Args:`, `Returns:`, `Example::` según corresponda.
+- El docstring es lo que los IDEs (VS Code, PyCharm) muestran como tooltip al
+  invocar la clase o el método.
+- Los **comentarios** de desarrollador (`# ...`) van en **español**.
+
+## Documentación
+
+- Documentar con **Mermaid** (diagramas de clases, arquitectura, flujos).
+- Estándar **UML** para lo propio y lo que se consume de FreeCAD.
+
+## Principios de diseño
+
+- **KISS** — Keep It Simple. Menos es más.
+- **SOLID** — Responsabilidad Única, Abierto/Cerrado, Sustitución de Liskov,
+  Segregación de Interfaces, Inversión de Dependencias.
+- **Arquitectura Document-View** — la misma que usa FreeCAD internamente
+  (Documento ↔ Vista ↔ Storage).
+
+## Regla crítica: subcontextos anidados, nunca aplanados
+
+Al armar el diccionario maestro de una carpeta, cada submenú va **como valor
+bajo su propia clave**, nunca fusionado con `.update(sub_dict)`:
+
+```python
+explorer.update({'file': file})   # CORRECTO — 'file' queda navegable
+explorer.update(file)             # INCORRECTO — aplana las hojas del hijo
+```
+
+Aplanar rompe dos cosas en silencio: colisiona claves repetidas entre hojas
+(`create`, `help`, `center`) quedándose solo con la última, y deja la carpeta
+fuera del árbol navegable, con lo cual su `TraduceTo*.py` no se carga nunca.
+Detalle completo en `pendientes-dav.md` §4.
+
+## Git / commits
+
+- **No agregar `Co-Authored-By` ni ninguna mención al asistente** en los
+  mensajes de commit.
+- **No hacer `commit` ni `push`** salvo que el usuario lo pida explícitamente.
+- Mensajes de commit en español, descriptivos (ej. `Sketcher: selección de
+  plano por voz al crear nuevo boceto`).
+- No commitear artefactos generados ni claves/secrets. Los modelos de voz en
+  `Dav/models/` están excluidos de git.
+
+---
+
+Siguiente: [Agregar un comando por voz](agregar-comando.md)

--- a/Dav/docs/desarrollo/estructura.md
+++ b/Dav/docs/desarrollo/estructura.md
@@ -1,0 +1,79 @@
+# Estructura del repositorio
+
+El repositorio mezcla dos cosas: el **código fuente de FreeCAD** (el fork base
+que se trae completo) y el **código propio de DAV** (la capa de voz). Es
+importante saber en qué mitad estás trabajando, porque los cabezales de
+licencia y las reglas son distintos.
+
+```
+DAV/
+├── FREECAD/          # Código fuente de FreeCAD (fork base, NO se toca de esto salvo que sea necesario)
+│   ├── src/          #   Módulos Python y C++ de FreeCAD
+│   │   ├── App/      #   Núcleo de la aplicación (FreeCADInit.py)
+│   │   ├── Gui/      #   Interfaz gráfica (FreeCADGuiInit.py)
+│   │   ├── Ext/freecad/  #   Extensiones Python propias de FreeCAD
+│   │   └── Mod/      #   Workbenches: Draft, Sketcher, Part, PartDesign,
+│   │                 #     Assembly, TechDraw, etc.
+│   └── CMakeLists.txt
+├── Dav/              # ⭐ TODO el código propio del proyecto DAV
+│   ├── dic/          #   Árbol de comandos por voz (ver abajo)
+│   ├── docs/         #   Documentación, planes, informes, normativas
+│   ├── models/       #   Modelos Vosk es/en/pt (excluidos de git)
+│   └── scr/          #   Código fuente en Python
+│       ├── ComponentesDAV/
+│       │   ├── IntegracionGUI/  # Motor Browser (navigation/) + montaje del panel
+│       │   ├── InterfazDAV/     # DavPanel: el widget de la GUI (sin FreeCAD)
+│       │   ├── Keychain/        # Lectura de claves de diccionarios
+│       │   ├── Dav/             # InitGui.py — arranque dentro de FreeCAD
+│       │   ├── Logos/
+│       │   └── scripts/
+│       ├── PruebaIntegracion/
+│       ├── selection/           # CreateObjects — extracción de sub-elementos
+│       └── validation/          # Validator — reglas de validación de comandos
+└── CLAUDE.md
+```
+
+## Dónde vive cada cosa
+
+| ¿Qué estás buscando? | ¿Dónde está? |
+|---|---|
+| Motor de navegación por voz (`Browser`) | `Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/navigation/browser.py` |
+| Árbol de comandos por voz | `Dav/dic/` |
+| Traducción frase hablada → comando | `TraduceTo*.py` dentro de cada carpeta de `Dav/dic/` |
+| Lectura de claves de diccionarios | `Dav/scr/ComponentesDAV/Keychain/` |
+| Widget de la GUI (panel) | `Dav/scr/ComponentesDAV/InterfazDAV/DavPanel.py` |
+| Extracción de sub-elementos (selección) | `Dav/scr/selection/` |
+| Validación de comandos | `Dav/scr/validation/` |
+| Modelos Vosk (no versionados) | `Dav/models/` |
+| Documentación del proyecto | `Dav/docs/` |
+
+## El árbol de comandos por voz (`Dav/dic/`)
+
+Cada **carpeta** del árbol es un **nivel de contexto** y tiene:
+
+- Un diccionario maestro: `<nombre>.py` con las **claves internas → callables**
+  de FreeCAD (ej. `explorer.py`, `sketcher.py`).
+- Traducciones por idioma: `TraduceToEs.py`, `TraduceToEn.py`, `TraduceToPT.py`
+  que mapean **frases habladas → los mismos callables**.
+
+`Dav/dic/base.py` es el punto de entrada: enlaza los módulos de nivel superior
+(`explorer`, `stdview`, `workbench`, `lineattributes`, `preferences`).
+
+El motor que recorre este árbol en runtime es `Browser`
+(`Dav/scr/.../GUIFreeCad/navigation/browser.py`) + `DictionaryLoader`
+(`navigation/dictionary_loader.py`).
+
+> ⚠️ Importante: aunque históricamente existió un `DAVAgent` con
+> `latentListening`, la implementación real usa `Browser.ProcessPhrase` +
+> `DictionaryLoader`. Si un diagrama viejo te muestra `DAVAgent`, es el diseño
+> conceptual original, no el código vigente.
+
+## La GUI es un panel acoplado
+
+El panel (`DavPanel`) es un `QDockWidget` que corre dentro de FreeCAD y se
+alimenta del `Browser` **en proceso** vía
+`Dav/scr/.../GUIFreeCad/integration/dav_dock_panel.py`. El widget no importa
+FreeCAD: se le pasan datos y emite señales, así se puede testear aparte.
+
+Ya no existen `MainWindow.py`, su motor de voz propio (`_VoiceMap`/`_GroupMeta`)
+ni `DiccionarioPrueba/`: se retiraron al acoplar el panel.

--- a/Dav/docs/desarrollo/probando.md
+++ b/Dav/docs/desarrollo/probando.md
@@ -1,0 +1,111 @@
+# Cómo probar y validar
+
+Cómo comprobar que un cambio anda **antes** de mandarlo a revisión. Distintas
+capas según lo que tocaste.
+
+---
+
+## 1. Prueba puramente técnica (rápida, sin FreeCAD)
+
+Para código Python propio (prompts, pants, módulos), al menos:
+
+### Sintaxis
+
+```bash
+# Windows (PowerShell)
+python -c "import ast; ast.parse(open(r'<archivo>', encoding='utf-8').read()); print('OK')"
+```
+
+### Import / smoke test con el venv de desarrollo
+
+El venv de desarrollo (`IntegracionGUI/GUIFreeCad/.venv`) tiene PySide6. Se
+puede importar un módulo que no requiera FreeCAD en tiempo de import (si
+importa `FreeCAD` arriba, usá import diferido dentro de las funciones — patrón
+que usan los prompts).
+
+### Lógica de prompts (sin abrir FreeCAD)
+
+Los prompts heredan `BaseInputPrompt` y su lógica se puede probar llamando
+`ProcessFinalText("...")` directamente con un `QApplication` offscreen:
+
+```python
+import os
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+from InputPrompts.PlaneSelectionInputPrompt import PlaneSelectionInputPrompt
+from PySide6.QtWidgets import QApplication
+app = QApplication.instance() or QApplication([])
+
+p = PlaneSelectionInputPrompt()
+print(p.ProcessFinalText("abajo").Success)   # navega
+print(p.ProcessFinalText("okey").Value)       # confirma → valor del plano
+```
+
+Requiere que `GUIFreeCad` esté en `sys.path` (o configurar la ruta).
+
+---
+
+## 2. Prueba de diccionarios / navegación
+
+- **Cargar el dict maestro** no debe romper: si una carpeta tiene un dict roto,
+  el `DictionaryLoader` lo omite y sigue (no tumba el motor).
+- Verificá que las **frases nuevas aparecen** como opciones del contexto: en el
+  panel, tras navegar al contexto, la ayuda/describir contexto listará los
+  comandos disponibles (implícito en `Browser.DescribeContext`).
+- Probá cada frase en los tres idiomas si agregaste traducciones.
+
+---
+
+## 3. Prueba integrada en FreeCAD (la que vale)
+
+Corré el motor de voz dentro de FreeCAD (ver [setup](setup.md)) y probá el
+flujo real por voz. Las guías existentes detallan qué esperar:
+
+| Guía | Cubre |
+|---|---|
+| [guia-pruebas-partdesign-voz.md](../guia-pruebas-partdesign-voz.md) | PartDesign por voz con medidas dictadas (sólidos, extrusión, cortes, acabados) |
+| [guia-pruebas-3d-voz.md](../guia-pruebas-3d-voz.md) | Flujo completo desde dibujo 2D y Assembly |
+| [guia-prueba-numeros-alumnos.md](../guia-prueba-numeros-alumnos.md) | Dictado de números (cómo decir medidas) |
+| [manual-selection-voz.md](../manual-selection-voz.md) | Selección de objetos por voz |
+| [manual-explorer-voz.md](../manual-explorer-voz.md) | Explorer por voz (archivos) |
+| [informe_pruebas_draftwork.md](../informe_pruebas_draftwork.md) | Reporte de pruebas del workbench Draft |
+
+### Consejos de prueba
+
+- **`donde estoy`** para ubicarte; **`subir`** para subir de nivel.
+- Confirmar pop-ups: `enter` · `enviar` · `aceptar` · `confirmar` · `ok`.
+  Abortar: `cancelar`.
+- Si un comando "no se escucha", pensá en la **gramática acotada**: algunos
+  prompts (numéricos, selector de plano) limitan qué palabras acepta Vosk a
+  propósito (ver [acortador-gramatica-vosk.md](../acortador-gramatica-vosk.md)).
+
+---
+
+## 4. Correr los tests del proyecto
+
+Hay infraestructura de tests/validación en `Dav/scr/validation/`:
+
+- `test_validator.py` — pruebas del `Validator`.
+- `test_integration.py` — pruebas de integración (incluye
+  `PromptedCommandExecutor`).
+- `run_tests.py` — correr los tests de la carpeta.
+- `prueba_validator.py` — helper de prueba/validación.
+
+```bash
+python Dav/scr/validation/run_tests.py
+```
+
+> El `Validator` se integra a la ejecución de comandos vía
+> `PromptedCommandExecutor` (validación previa de parámetros). Si tu comando
+> toma parámetros, añadí cobertura en estas pruebas cuando corresponda.
+
+---
+
+## Checklist rápido antes de mandar el PR
+
+- [ ] Sintaxis OK (AST parse) en archivos modificados/nuevos.
+- [ ] No se aplanan subcontextos (`.update(sub_dict)`).
+- [ ] Archivos nuevos con cabezal obligatorio.
+- [ ] Docstrings en inglés para clases/métodos públicos.
+- [ ] Frases probadas en los idiomas que toquen.
+- [ ] Flujo real por voz probado en FreeCAD (si se puede).
+- [ ] Actualizada la guía/doc si cambiaste una convención o un comportamiento.

--- a/Dav/docs/desarrollo/setup.md
+++ b/Dav/docs/desarrollo/setup.md
@@ -1,0 +1,127 @@
+# Puesta en marcha (setup)
+
+Guía para levantar DAV y probar el motor de voz en una máquina local.
+
+> ⚠️ **Los dos intérpretes.** El venv de desarrollo
+> (`IntegracionGUI/GUIFreeCad/.venv`) usa Python más nuevo que el Python
+> embebido de FreeCAD. El código tiene que correr en ambos: **los scripts que
+> se cargan dentro de FreeCAD usan el intérprete de FreeCAD, no el venv.**
+> Las extensiones de FreeCAD deben usar **PySide6**, no PyQt, por
+> compatibilidad constructiva con el framework nativo.
+
+## 1. Clonar el repositorio
+
+El flujo de contribución se hace con **fork personal** + **Pull Request** (ver
+el flujo completo en `CLAUDE.md` y en `guia-desarrollo-dav.md` → GitFlow).
+
+```bash
+git clone https://github.com/<tu-usuario>/DAV.git
+cd DAV
+```
+
+Si querés el repositorio central directo:
+
+```bash
+git clone https://github.com/DAv-Project-Team-UADER/DAV.git
+```
+
+## 2. Dependencias Python (venv de desarrollo)
+
+El entorno de desarrollo vive en
+`Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/.venv` con las dependencias
+declaradas en `requirements.txt`:
+
+```
+PySide6>=6.6.0
+vosk>=0.3.45
+sounddevice>=0.4.6
+numpy>=1.24.0
+requests>=2.31.0
+tqdm>=4.66.0
+```
+
+Para recrearlo/instalarlo:
+
+```bash
+cd Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad
+python -m venv .venv
+.venv\Scripts\activate          # Windows
+# o: source .venv/bin/activate  # Linux/macOS
+pip install -r requirements.txt
+```
+
+> Este venv sirve para **desarrollar/testear el widget de GUI y prompts** de
+> forma aislada. Para probar la voz **dentro de FreeCAD** hay que tener las
+> dependencias disponibles para el intérprete de FreeCAD (módulos instalados
+> en el entorno que corre FreeCAD).
+
+## 3. Modelos de voz Vosk
+
+Los modelos viven en `Dav/models/` (excluidos de git — ver
+`Dav/models/README.md`):
+
+| Modelo | Idioma |
+|---|---|
+| `vosk-model-small-es-0.42` | Español |
+| `vosk-model-small-en-us-0.15` | Inglés |
+| `vosk-model-small-pt-0.3` | Portugués |
+
+No hace falta descargarlos a mano: `core/model_manager.py` y
+`ui/download_dialog.py` (en `IntegracionGUI/GUIFreeCad/`) los descargan si
+faltan. También existe el script `scripts/setup_models.py`.
+
+> Para mayor precisión en español existe `vosk-model-es-0.42` (más pesado), no
+> incluido por defecto.
+
+## 4. Correr DAV dentro de FreeCAD
+
+DAV arranca dentro de la **consola Python** de FreeCAD (Vista → Paneles →
+Consola de Python) o como **macro**. El `DAVCore` debe iniciarse igual que
+`FreeCADGuiInit.py`, es decir al arrancar la aplicación.
+
+Pasos generales:
+
+1. Abrí FreeCAD con un documento nuevo.
+2. Abrí la **Consola de Python**.
+3. Cargá y ejecutá el arranque del motor de voz (el bootstrap que monta el
+   `Browser` + micrófono). Ver `integration/voice_bootstrap.py` y el
+   `InitGui.py` en `scr/.../Dav/` para el arranque automático con FreeCAD.
+4. Configurá el idioma en **Preferencias DAV** si no es español.
+
+> El panel DAV se monta como `QDockWidget` dentro de FreeCAD vía
+> `integration/dav_dock_panel.py`. Si arranca como ventana flotante, se puede
+> anclar a cualquier borde.
+
+## 5. Comandos básicos para verificar el setup
+
+Con el motor activo, probá frases de navegación del propio Browser (no tocan
+nada del documento):
+
+- **`donde estoy`** — muestra el contexto actual.
+- **`subir`** — sube un nivel del árbol de navegación.
+
+Y un comando real, por ejemplo:
+
+```
+banco de trabajo → diseñador de piezas    (ir al workbench PartDesign)
+```
+
+Los comandos de confirmación/aborto de pop-ups (compartidos por los prompts):
+
+- **Confirmar un valor**: `enter` · `enviar` · `aceptar` · `confirmar` · `ok`
+- **Abortar un pop-up**: `cancelar`
+
+## Puertos / problemas comunes
+
+- **El micrófono usa PyAudio/SoundDevice** — si no se abre el stream, revisá
+  que el dispositivo esté disponible y desocupado.
+- **No se cargó el modelo** → confirmá que exista en `Dav/models/<idioma>` o
+  que `setup_models.py` lo haya descargado.
+- **La gramática está acotada por contexto** — ciertos prompts (numéricos, de
+  selección de plano) limitan qué palabras escucha Vosk a propósito. Si un
+  comando "no se entiende", revisá si hay un prompt activo acotando la
+  gramática (ver `acortador-gramatica-vosk.md`).
+
+---
+
+Siguiente: [Convenciones de código](convenciones.md)

--- a/Dav/docs/guia-desarrollo-dav.md
+++ b/Dav/docs/guia-desarrollo-dav.md
@@ -1,0 +1,54 @@
+# Guía de desarrollo de DAV
+
+> **DAV — Diseño Asistido por Voz**
+> Práctica Educativa Territorial — Facultad de Ciencia y Tecnología (FCyT) — UADER
+
+Esta guía explica **cómo se desarrolla y contribuye al proyecto DAV**: cómo
+ponerlo en marcha, qué convenciones seguir, cómo agregar un comando por voz y
+cómo probar los cambios. Está pensada para integrantes del equipo que se
+suman al desarrollo, tanto para el código propio de DAV como para el
+diccionario de comandos por voz.
+
+Está escrita desde lo aprendido en la práctica. Si algo quedó desactualizado o
+cambiás una convención, **actualizá esta guía** en el mismo PR que toca el
+código.
+
+---
+
+## Índice
+
+| Sección | Contenido |
+|---|---|
+| [Estructura del repositorio](desarrollo/estructura.md) | Qué hace cada carpeta del repo y dónde vive cada cosa |
+| [Puesta en marcha (setup)](desarrollo/setup.md) | Cómo clonar, instalar dependencias, modelos y correr DAV en FreeCAD |
+| [Convenciones de código](desarrollo/convenciones.md) | Nombres, cabezal obligatorio, docstrings, principios de diseño |
+| [Agregar un comando por voz](desarrollo/agregar-comando.md) | Paso a paso con ejemplo real, desde el diccionario hasta el TraduceTo |
+| [Cómo probar y validar](desarrollo/probando.md) | Pruebas manuales, qué esperar, y enlaces a las guías existentes |
+
+---
+
+## Resumen rápido
+
+- **DAV** es una capa de control por **voz** sobre **FreeCAD** usando **Vosk**
+  como reconocedor.
+- El código propio vive en `Dav/`; el árbol de comandos por voz en `Dav/dic/`;
+  el motor que recorre ese árbol es `Browser`
+  (`Dav/scr/.../navigation/browser.py`).
+- Las frases habladas se definen en los `TraduceToEs.py` / `TraduceToEn.py` /
+  `TraduceToPT.py` de cada carpeta; el diccionario maestro de cada carpeta
+  enlaza las claves internas con callables de FreeCAD.
+- Regla de oro: **los subcontextos van anidados bajo su propia clave**, nunca
+  aplanados con `.update(sub_dict)`. Ver [pendientes-dav.md](pendientes-dav.md) §4.
+
+---
+
+## Material de referencia
+
+- **[CLAUDE.md](../../CLAUDE.md)** — documentación general del proyecto:
+  arquitectura, GitFlow, modelo de voz, licencias. Es la fuente de la mayoría
+  de las convenciones citadas acá.
+- **[pendientes-dav.md](pendientes-dav.md)** — lo que sigue abierto. **Leer
+  antes de tocar diccionarios o navegación.**
+- **[completados-dav.md](completados-dav.md)** — problemas ya resueltos y su
+  causa real. Consultar antes de re-diagnosticar algo conocido.
+- `README.md` / `README.es.md` / `README.pt.md` — presentación del proyecto.


### PR DESCRIPTION
La guía de desarrollo es un set de documentos que explica cómo se desarrolla y contribuye a DAV. Tiene 5 secciones:

Estructura del repositorio — qué hace cada carpeta (Dav/dic/, Dav/scr/, FREECAD/) y dónde vive cada cosa.
Puesta en marcha (setup) — cómo clonar, instalar dependencias y modelos Vosk, y correr el motor dentro de FreeCAD.
Convenciones de código — nomenclatura, cabezal de licencia obligatorio, docstrings, principios de diseño y la regla de subcontextos anidados.
Agregar un comando por voz — paso a paso con un ejemplo real (el selector de plano por voz que hiciste).
Cómo probar y validar — pruebas técnicas, de diccionarios, integradas en FreeCAD, tests y el checklist previo al PR.
Está pensada para que alguien que se suma al equipo pueda entender la arquitectura y sumar un comando por voz sin romper nada.