### PR TITLE
feat(sketcher): add 3-point parametric arc and active sketch support …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/config/voice_history.log
 
 .gemini/
 ComponentesDAV/
+*.pptx
 
 # Los scripts reales del proyecto viven en Dav/scr/ComponentesDAV/scripts.
 # La regla "ComponentesDAV/" (a cualquier profundidad) es para la copia

--- a/Dav/dic/Workbench/Sketcher/Geometry/arc/TraduceToEs.py
+++ b/Dav/dic/Workbench/Sketcher/Geometry/arc/TraduceToEs.py
@@ -37,4 +37,11 @@ TraduceToEs = {
     "crear arco por centro": arc['create_by_center'],
     "arco por angulos": arc['create_by_center'],
     "arco por coordenadas": arc['create_by_center'],
+
+    # Arco por 3 puntos (6 floats: p1, p2, p3)
+    "arco por tres puntos": arc['create_by_3points'],
+    "arco de tres puntos": arc['create_by_3points'],
+    "crear arco por tres puntos": arc['create_by_3points'],
+    "tres puntos por coordenadas": arc['create_by_3points'],
+    "arco tres puntos por parametros": arc['create_by_3points'],
 }

--- a/Dav/dic/Workbench/Sketcher/Geometry/arc/_parametric.py
+++ b/Dav/dic/Workbench/Sketcher/Geometry/arc/_parametric.py
@@ -65,13 +65,25 @@ def create_by_center(
         print("[geometry.arc] Error: start and end angles describe an empty sweep.")
         return
 
-    safe_name = "".join(ch for ch in label if ch.isalnum()) or "Arc"
     circle = Part.Circle(App.Vector(x, y, 0), App.Vector(0, 0, 1), radius)
-    shape = Part.ArcOfCircle(
+    arc_geo = Part.ArcOfCircle(
         circle,
         math.radians(angle_start),
         math.radians(angle_end),
-    ).toShape()
+    )
+
+    sketch = getattr(doc, "ActiveObject", None)
+    if sketch and getattr(sketch, "TypeId", "") == "Sketcher::SketchObject":
+        sketch.addGeometry(arc_geo, False)
+        doc.recompute()
+        print(
+            f"[geometry.arc] Added arc to sketch at ({x},{y}) radius {radius} "
+            f"from {angle_start} to {angle_end} degrees"
+        )
+        return
+
+    safe_name = "".join(ch for ch in label if ch.isalnum()) or "Arc"
+    shape = arc_geo.toShape()
 
     feature = doc.addObject("Part::Feature", safe_name)
     feature.Label = label
@@ -80,4 +92,49 @@ def create_by_center(
     print(
         f"[geometry.arc] Created '{label}' at ({x},{y}) radius {radius} "
         f"from {angle_start} to {angle_end} degrees"
+    )
+
+
+def create_by_3points(
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    x3: float,
+    y3: float,
+    label: str = "Arc",
+) -> None:
+    """Create an arc passing through 3 points (p1: start, p2: midpoint/minimum, p3: end)."""
+    doc = App.activeDocument()
+    if doc is None:
+        print("[geometry.arc] Error: no active document.")
+        return
+
+    p1 = App.Vector(x1, y1, 0)
+    p2 = App.Vector(x2, y2, 0)
+    p3 = App.Vector(x3, y3, 0)
+
+    try:
+        arc_geo = Part.ArcOfCircle(p1, p2, p3)
+    except Exception as exc:
+        print(f"[geometry.arc] Error creating 3-point arc: {exc}")
+        return
+
+    sketch = getattr(doc, "ActiveObject", None)
+    if sketch and getattr(sketch, "TypeId", "") == "Sketcher::SketchObject":
+        sketch.addGeometry(arc_geo, False)
+        doc.recompute()
+        print(
+            f"[geometry.arc] Added 3-point arc to sketch through ({x1},{y1}), ({x2},{y2}), ({x3},{y3})"
+        )
+        return
+
+    safe_name = "".join(ch for ch in label if ch.isalnum()) or "Arc"
+    shape = arc_geo.toShape()
+    feature = doc.addObject("Part::Feature", safe_name)
+    feature.Label = label
+    feature.Shape = shape
+    doc.recompute()
+    print(
+        f"[geometry.arc] Created 3-point arc '{label}' through ({x1},{y1}), ({x2},{y2}), ({x3},{y3})"
     )

--- a/Dav/dic/Workbench/Sketcher/Geometry/arc/arc.py
+++ b/Dav/dic/Workbench/Sketcher/Geometry/arc/arc.py
@@ -4,7 +4,7 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 from .ayuda import ayuda
-from ._parametric import create_by_center
+from ._parametric import create_by_center, create_by_3points
 from selection.createobjects import CreateObjects
 
 def _execute_with_objects(command):
@@ -20,9 +20,17 @@ def create_by_center_with_objects(x: float, y: float, radius: float, angle_start
     if active_doc and active_doc.ActiveObject:
         CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
 
+
+def create_by_3points_with_objects(x1: float, y1: float, x2: float, y2: float, x3: float, y3: float, label: str = "Arc"):
+    create_by_3points(x1=x1, y1=y1, x2=x2, y2=y2, x3=x3, y3=y3, label=label)
+    active_doc = App.ActiveDocument
+    if active_doc and active_doc.ActiveObject:
+        CreateObjects(ObjectName=active_doc.ActiveObject.Name, Is3D=False).Execute()
+
 arc = {
     'center': lambda: _execute_with_objects('Sketcher_CreateArc'),
     '3point': lambda: _execute_with_objects('Sketcher_Create3PointArc'),
     'create_by_center': create_by_center_with_objects,
+    'create_by_3points': create_by_3points_with_objects,
     'help':   ayuda
 }

--- a/Dav/dic/Workbench/Sketcher/Geometry/line/_parametric.py
+++ b/Dav/dic/Workbench/Sketcher/Geometry/line/_parametric.py
@@ -22,6 +22,13 @@ def create_by_points(
         print("[geometry.line] Error: no active document.")
         return
 
+    sketch = getattr(doc, "ActiveObject", None)
+    if sketch and getattr(sketch, "TypeId", "") == "Sketcher::SketchObject":
+        sketch.addGeometry(Part.LineSegment(App.Vector(x1, y1, 0), App.Vector(x2, y2, 0)), False)
+        doc.recompute()
+        print(f"[geometry.line] Added line to sketch from ({x1},{y1}) to ({x2},{y2})")
+        return
+
     safe_name = "".join(ch for ch in label if ch.isalnum()) or "Segment"
     segment = Part.makeLine(App.Vector(x1, y1, 0), App.Vector(x2, y2, 0))
     feature = doc.addObject("Part::Feature", safe_name)


### PR DESCRIPTION
## Descripción
- Se implementó la función paramétrica por voz `create_by_3points` en `Sketcher/Geometry/arc` para permitir crear arcos a partir de 3 puntos (inicio, punto mínimo y fin) con sus sinónimos en español.
- Se agregó soporte para que `arc` y `line` inserten las geometrías directamente adentro del croquis activo (`sketch.addGeometry`).
