### PR TITLE
feat(dav): agrega controles globales del panel DAV

### DIFF
--- a/Dav/dic/TraduceToEs.py
+++ b/Dav/dic/TraduceToEs.py
@@ -23,6 +23,7 @@ from StdView.StdView import StdView
 from Explorer.Explorer import explorer
 from LineAttributes.LineAttributes import LineAttributes
 from Selection.selection import selection
+from integration.dav_dock_panel import hide_dav_panel, show_dav_panel
 from integration.launch_preferences import open_preferences
 
 TraduceToEs = {
@@ -69,4 +70,12 @@ TraduceToEs = {
     "preferencias":  open_preferences,
     "configuracion": open_preferences,
     "ajustes":       open_preferences,
+
+    # Panel DAV
+    "minimizar":  hide_dav_panel,
+    "reducir":    hide_dav_panel,
+    "disminuir":  hide_dav_panel,
+    "maximizar":  show_dav_panel,
+    "aumentar":   show_dav_panel,
+    "agrandar":   show_dav_panel,
 }

--- a/Dav/dic/base.py
+++ b/Dav/dic/base.py
@@ -32,6 +32,7 @@ from StdView.StdView import StdView
 from Workbench.workbench import workbench
 from LineAttributes.LineAttributes import LineAttributes
 from Selection.selection import selection
+from integration.dav_dock_panel import hide_dav_panel, show_dav_panel
 from integration.launch_preferences import open_preferences
 
 Base = {
@@ -41,4 +42,6 @@ Base = {
     "lineattributes": LineAttributes,
     "selection":      selection,
     "preferences":    open_preferences,
+    "hide_dav_panel": hide_dav_panel,
+    "show_dav_panel": show_dav_panel,
 }

--- a/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/integration/dav_dock_panel.py
+++ b/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/integration/dav_dock_panel.py
@@ -28,6 +28,19 @@ _observer = None
 _selection_observer = None
 
 
+def hide_dav_panel() -> None:
+    """Hide the DAV dock panel when it is mounted."""
+    if _dock is not None:
+        _dock.hide()
+
+
+def show_dav_panel() -> None:
+    """Show and foreground the DAV dock panel when it is mounted."""
+    if _dock is not None:
+        _dock.show()
+        _dock.raise_()
+
+
 def _ensure_interfaz_on_path() -> None:
     """Make ``InterfazDAV`` importable (it lives outside GUIFreeCad)."""
     here = Path(__file__).resolve()

--- a/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/tests/test_dav_dock_panel.py
+++ b/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/tests/test_dav_dock_panel.py
@@ -1,0 +1,76 @@
+#  Copyright (C) 2026 The DAV Project Team
+#  Universidad Autónoma de Entre Ríos (UADER)
+#  SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for idempotent visibility controls of the DAV dock."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+GUI_ROOT = Path(__file__).resolve().parents[1]
+if str(GUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(GUI_ROOT))
+
+
+class _FakeDock:
+    def __init__(self, visible: bool) -> None:
+        self.visible = visible
+        self.show_calls = 0
+        self.hide_calls = 0
+        self.raise_calls = 0
+
+    def isVisible(self) -> bool:
+        return self.visible
+
+    def show(self) -> None:
+        self.show_calls += 1
+        self.visible = True
+
+    def hide(self) -> None:
+        self.hide_calls += 1
+        self.visible = False
+
+    def raise_(self) -> None:
+        self.raise_calls += 1
+
+
+class TestDavDockPanelVisibility(unittest.TestCase):
+    """Verify explicit DAV panel visibility actions."""
+
+    def setUp(self) -> None:
+        from integration import dav_dock_panel
+
+        self.module = dav_dock_panel
+        self.previous_dock = self.module._dock
+
+    def tearDown(self) -> None:
+        self.module._dock = self.previous_dock
+
+    def test_hide_dav_panel_hides_visible_dock(self) -> None:
+        self.assertTrue(hasattr(self.module, "hide_dav_panel"))
+        dock = _FakeDock(visible=True)
+        self.module._dock = dock
+
+        self.module.hide_dav_panel()
+
+        self.assertFalse(dock.visible)
+        self.assertEqual(dock.hide_calls, 1)
+
+    def test_show_dav_panel_shows_and_foregrounds_hidden_dock(self) -> None:
+        self.assertTrue(hasattr(self.module, "show_dav_panel"))
+        dock = _FakeDock(visible=False)
+        self.module._dock = dock
+
+        self.module.show_dav_panel()
+
+        self.assertTrue(dock.visible)
+        self.assertEqual(dock.show_calls, 1)
+        self.assertEqual(dock.raise_calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/tests/test_real_dictionaries.py
+++ b/Dav/scr/ComponentesDAV/IntegracionGUI/GUIFreeCad/tests/test_real_dictionaries.py
@@ -59,6 +59,10 @@ def _install_freecad_stub() -> None:
     for mod in ("Part", "PartDesign", "Sketcher", "Draft", "TechDraw", "Assembly", "Mesh", "Fem"):
         if mod not in sys.modules:
             sys.modules[mod] = types.ModuleType(mod)
+    if "integration.launch_preferences" not in sys.modules:
+        preferences = types.ModuleType("integration.launch_preferences")
+        preferences.open_preferences = lambda: None  # type: ignore[attr-defined]
+        sys.modules["integration.launch_preferences"] = preferences
 
 
 class TestRealDictionariesConvention(unittest.TestCase):
@@ -139,6 +143,24 @@ class TestRealDictionariesConvention(unittest.TestCase):
                 workbench,
                 f"Workbench missing nested key '{submenu}'. Check workbench.py nesting!",
             )
+
+    def test_dav_panel_visibility_commands_are_global_in_spanish(self) -> None:
+        """Verify Spanish panel visibility aliases resolve from the base dictionary."""
+        from core.language_code import LanguageCode
+        from navigation.dictionary_loader import DictionaryLoader
+
+        loader = DictionaryLoader(DIC_ROOT)
+        base_dict = loader.LoadBaseModuleDict()
+        spanish = loader.LoadTranslateMap(DIC_ROOT, LanguageCode.Es)
+
+        self.assertIn("hide_dav_panel", base_dict)
+        self.assertIn("show_dav_panel", base_dict)
+
+        for phrase in ("minimizar", "reducir", "disminuir"):
+            self.assertIs(spanish[phrase], base_dict["hide_dav_panel"])
+        for phrase in ("maximizar", "aumentar", "agrandar"):
+            self.assertIs(spanish[phrase], base_dict["show_dav_panel"])
+
     def test_techdraw_and_geometry_translations_populated(self) -> None:
         """Verify that TechDraw and Sketcher/Geometry translations are populated and not empty stubs."""
         from navigation.dictionary_loader import DictionaryLoader


### PR DESCRIPTION
Se incorporan controles de voz globales para gestionar la visibilidad del panel DAV desde cualquier contexto del navegador de comandos.

Se agregan dos acciones independientes en `integration/dav_dock_panel.py`:

- `hide_dav_panel()`: oculta el dock `DAV_Panel`.
- `show_dav_panel()`: muestra el dock y lo trae al frente.

Ambas acciones son idempotentes: repetir “minimizar” mantiene el panel oculto y repetir “maximizar” mantiene el panel visible. No usan `Std_PanelView`, ya que ese comando alterna el panel activo de FreeCAD y no garantiza que el objetivo sea DAV.

Los comandos se registran en `Dav/dic/base.py` y se agregan los siguientes aliases en `Dav/dic/TraduceToEs.py`:

- Ocultar: `minimizar`, `reducir`, `disminuir`.
- Mostrar: `maximizar`, `aumentar`, `agrandar`.

También se agregan pruebas para validar la visibilidad del dock y que los aliases españoles resuelvan a los comandos globales correctos.

Pruebas ejecutadas:
- `test_dav_dock_panel.py`
- `test_real_dictionaries.py`